### PR TITLE
feat: Safe-DS stubs also contain docstring information.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ __pycache__/
 
 # Python environment
 venv/
+.venv/
 
 # Pytest outputs
 .mypy_cache/

--- a/src/safeds_stubgen/api_analyzer/_ast_walker.py
+++ b/src/safeds_stubgen/api_analyzer/_ast_walker.py
@@ -97,10 +97,7 @@ class ASTWalker:
                 raise AttributeError("Expected classdef node to have attribute 'base_type_exprs'.")
 
             for superclass in node.base_type_exprs:
-                if (
-                    (hasattr(superclass, "fullname") and superclass.fullname in ("enum.Enum", "enum.IntEnum")) or
-                    (hasattr(superclass, "name") and superclass.name in ("Enum", "IntEnum"))
-                ):
+                if hasattr(superclass, "fullname") and superclass.fullname in ("enum.Enum", "enum.IntEnum"):
                     class_name = "enumdef"
         elif class_name == "mypyfile":
             class_name = "moduledef"

--- a/src/safeds_stubgen/api_analyzer/_ast_walker.py
+++ b/src/safeds_stubgen/api_analyzer/_ast_walker.py
@@ -97,7 +97,10 @@ class ASTWalker:
                 raise AttributeError("Expected classdef node to have attribute 'base_type_exprs'.")
 
             for superclass in node.base_type_exprs:
-                if hasattr(superclass, "fullname") and superclass.fullname in ("enum.Enum", "enum.IntEnum"):
+                if (
+                    (hasattr(superclass, "fullname") and superclass.fullname in ("enum.Enum", "enum.IntEnum")) or
+                    (hasattr(superclass, "name") and superclass.name in ("Enum", "IntEnum"))
+                ):
                     class_name = "enumdef"
         elif class_name == "mypyfile":
             class_name = "moduledef"

--- a/src/safeds_stubgen/stubs_generator/_generate_stubs.py
+++ b/src/safeds_stubgen/stubs_generator/_generate_stubs.py
@@ -17,10 +17,9 @@ from safeds_stubgen.api_analyzer import (
     UnionType,
     VarianceKind,
 )
-from safeds_stubgen.docstring_parsing import ClassDocstring, FunctionDocstring, ParameterDocstring, ResultDocstring, \
-    AttributeDocstring
 
 if TYPE_CHECKING:
+    from safeds_stubgen.docstring_parsing import ClassDocstring, FunctionDocstring, AttributeDocstring
     from collections.abc import Generator
 
 

--- a/src/safeds_stubgen/stubs_generator/_generate_stubs.py
+++ b/src/safeds_stubgen/stubs_generator/_generate_stubs.py
@@ -954,8 +954,8 @@ class StubsStringGenerator:
         description = description.replace("\n", f"\n{indentations} * ")
         return f"{indentations}/**\n{indentations} * {description}\n{indentations} */\n"
 
-    @staticmethod
     def _create_sds_docstring(
+        self,
         docstring: ClassDocstring | FunctionDocstring | AttributeDocstring,
         indentations: str,
         node: Class | Function | None = None,
@@ -988,7 +988,8 @@ class StubsStringGenerator:
 
                     param_desc = f"\n{indentations} * ".join(param_desc.split("\n"))
 
-                    parameter_docstrings.append(f"{indentations} * @param {parameter.name} {param_desc}\n")
+                    parameter_name = _convert_name_to_convention(parameter.name, self.naming_convention)
+                    parameter_docstrings.append(f"{indentations} * @param {parameter_name} {param_desc}\n")
 
                 full_parameter_docstring = "".join(parameter_docstrings)
 
@@ -1007,7 +1008,8 @@ class StubsStringGenerator:
 
                 result_desc = f"\n{indentations} * ".join(result_desc.split("\n"))
 
-                result_docstrings.append(f"{indentations} * @result {result.name} {result_desc}\n")
+                result_name = _convert_name_to_convention(result.name, self.naming_convention)
+                result_docstrings.append(f"{indentations} * @result {result_name} {result_desc}\n")
 
             full_result_docstring = "".join(result_docstrings)
 

--- a/src/safeds_stubgen/stubs_generator/_generate_stubs.py
+++ b/src/safeds_stubgen/stubs_generator/_generate_stubs.py
@@ -409,10 +409,19 @@ class StubsStringGenerator:
             if not type_string:
                 self._current_todo_msgs.add("attr without type")
 
+            # Create docstring text
+            docstring = ""
+            doc_desc = attribute.docstring.description
+            if doc_desc:
+                docstring += f"{inner_indentations}/**\n"
+                doc_desc.replace("\n", f"\n{inner_indentations} * ")
+                docstring += f"{inner_indentations} * {doc_desc}\n"
+                docstring += f"{inner_indentations} */\n"
+
             # Create attribute string
             class_attributes.append(
                 f"{self._create_todo_msg(inner_indentations)}"
-                f"{inner_indentations}{attr_name_annotation}"
+                f"{docstring}{inner_indentations}{attr_name_annotation}"
                 f"{static_string}attr {attr_name_camel_case}"
                 f"{type_string}",
             )

--- a/src/safeds_stubgen/stubs_generator/_generate_stubs.py
+++ b/src/safeds_stubgen/stubs_generator/_generate_stubs.py
@@ -517,7 +517,7 @@ class StubsStringGenerator:
         camel_case_name = _replace_if_safeds_keyword(camel_case_name)
 
         # Docstring
-        docstring = self._create_sds_docstring(function.docstring, indentations, function)
+        docstring = self._create_sds_docstring_description(function.docstring.description, indentations)
 
         # Create type information
         result_types = [result.type for result in function.results if result.type is not None]

--- a/src/safeds_stubgen/stubs_generator/_generate_stubs.py
+++ b/src/safeds_stubgen/stubs_generator/_generate_stubs.py
@@ -66,11 +66,11 @@ def _generate_stubs_data(
         # the file would look like this: "package path.to.myPackage\n" or this:
         # '@PythonModule("path.to.my_package")\npackage path.to.myPackage\n'. With the split we check if the module
         # has enough information, if not, we won't create it.
-        splitted_text = module_text
-        if module_text.startswith("/**"):
+        _module_text = module_text
+        if _module_text.startswith("/**"):
             # Remove docstring
-            splitted_text = "*/\n".join(module_text.split("*/\n\n")[1:])
-        splitted_text = splitted_text.split("\n")
+            _module_text = "*/\n".join(_module_text.split("*/\n\n")[1:])
+        splitted_text = _module_text.split("\n")
         if len(splitted_text) <= 2 or (len(splitted_text) == 3 and splitted_text[1].startswith("package ")):
             continue
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any
 
 import pytest
@@ -10,7 +11,8 @@ class SdsStubExtension(SingleFileSnapshotExtension):
     _file_extension = "sdsstub"
 
     def serialize(self, data: str, **_kwargs: Any) -> SerializedData:
-        return bytes(data, encoding="utf8")
+        normalized_data = re.sub(r"\r?\n", "\n", data)
+        return bytes(normalized_data, encoding="utf8")
 
 
 @pytest.fixture()

--- a/tests/data/docstring_parser_package/epydoc.py
+++ b/tests/data/docstring_parser_package/epydoc.py
@@ -1,3 +1,10 @@
+"""
+Test module for docstring tests.
+
+A module for testing the various docstring types.
+"""
+
+
 class ClassWithDocumentation:
     """
     Lorem ipsum. Code::
@@ -112,6 +119,40 @@ def function_with_result_value_no_type() -> None:
 
 
 def function_without_result_value():
+    """
+    Lorem ipsum.
+
+    Dolor sit amet.
+    """
+
+
+class ClassWithMethod:
+    def method_with_docstring(self, a) -> bool:
+        """
+        Lorem ipsum.
+
+        Dolor sit amet.
+
+        @param a: type but no default
+        @type a: int
+
+        @return: return value
+        @rtype: bool
+        """
+
+    @property
+    def property_method_with_docstring(self):
+        """
+        Lorem ipsum.
+
+        Dolor sit amet.
+
+        @return: return value
+        @rtype: bool
+        """
+
+
+class EnumDocstring(Enum):
     """
     Lorem ipsum.
 

--- a/tests/data/docstring_parser_package/epydoc.py
+++ b/tests/data/docstring_parser_package/epydoc.py
@@ -3,6 +3,7 @@ Test module for docstring tests.
 
 A module for testing the various docstring types.
 """
+from enum import Enum
 
 
 class ClassWithDocumentation:

--- a/tests/data/docstring_parser_package/epydoc.py
+++ b/tests/data/docstring_parser_package/epydoc.py
@@ -87,8 +87,6 @@ def function_with_parameters(no_type_no_default, type_no_default, with_default, 
 
     Dolor sit amet.
 
-    Parameters
-    ----------
     @param no_type_no_default: no type and no default
     @param type_no_default: type but no default
     @type type_no_default: int

--- a/tests/data/docstring_parser_package/epydoc.py
+++ b/tests/data/docstring_parser_package/epydoc.py
@@ -36,7 +36,7 @@ class ClassWithParameters:
     @type p: int
     """
 
-    def __init__(self) -> None:
+    def __init__(self, p) -> None:
         pass
 
 
@@ -48,7 +48,11 @@ class ClassWithAttributes:
 
     @ivar p: foo defaults to 1
     @type p: int
+    @ivar q: foo defaults to 1
+    @type q: int
     """
+    p: int
+    q = 1
 
     def __init__(self) -> None:
         pass
@@ -61,13 +65,16 @@ class ClassWithAttributesNoType:
     Dolor sit amet.
 
     @ivar p: foo defaults to 1
+    @ivar q: foo defaults to 1
     """
+    p: int
+    q = 1
 
     def __init__(self) -> None:
         pass
 
 
-def function_with_parameters() -> None:
+def function_with_parameters(no_type_no_default, type_no_default, with_default, *args, **kwargs) -> None:
     """
     Lorem ipsum.
 
@@ -83,14 +90,14 @@ def function_with_parameters() -> None:
     """
 
 
-def function_with_result_value_and_type() -> None:
+def function_with_result_value_and_type() -> bool:
     """
     Lorem ipsum.
 
     Dolor sit amet.
 
     @return: return value
-    @rtype: float
+    @rtype: bool
     """
 
 
@@ -104,7 +111,7 @@ def function_with_result_value_no_type() -> None:
     """
 
 
-def function_without_result_value() -> None:
+def function_without_result_value():
     """
     Lorem ipsum.
 

--- a/tests/data/docstring_parser_package/epydoc.py
+++ b/tests/data/docstring_parser_package/epydoc.py
@@ -140,7 +140,7 @@ class ClassWithMethod:
         """
 
     @property
-    def property_method_with_docstring(self):
+    def property_method_with_docstring(self) -> bool:
         """
         Lorem ipsum.
 

--- a/tests/data/docstring_parser_package/full_docstring.py
+++ b/tests/data/docstring_parser_package/full_docstring.py
@@ -1,3 +1,10 @@
+"""
+Test module for docstring tests.
+
+A module for testing the various docstring types.
+"""
+
+
 class ClassWithMultiLineDocumentation:
     """
     Lorem ipsum.

--- a/tests/data/docstring_parser_package/full_docstring.py
+++ b/tests/data/docstring_parser_package/full_docstring.py
@@ -1,5 +1,5 @@
 """
-Test module for docstring tests.
+Test module for full docstring tests.
 
 A module for testing the various docstring types.
 """
@@ -7,14 +7,14 @@ A module for testing the various docstring types.
 
 class ClassWithMultiLineDocumentation:
     """
-    Lorem ipsum.
+    ClassWithMultiLineDocumentation.
 
     Dolor sit amet.
     """
 
 
 class ClassWithSingleLineDocumentation:
-    """Lorem ipsum."""
+    """ClassWithSingleLineDocumentation."""
 
 
 class ClassWithoutDocumentation:
@@ -23,14 +23,14 @@ class ClassWithoutDocumentation:
 
 def function_with_multi_line_documentation() -> None:
     """
-    Lorem ipsum.
+    function_with_multi_line_documentation.
 
     Dolor sit amet.
     """
 
 
 def function_with_single_line_documentation() -> None:
-    """Lorem ipsum."""
+    """function_with_single_line_documentation."""
 
 
 def function_without_documentation() -> None:

--- a/tests/data/docstring_parser_package/googledoc.py
+++ b/tests/data/docstring_parser_package/googledoc.py
@@ -1,4 +1,4 @@
-"""Test module for docstring tests.
+"""Test module for Google docstring tests.
 
 A module for testing the various docstring types.
 """
@@ -7,7 +7,7 @@ from enum import Enum
 
 class ClassWithDocumentation:
     """
-    Lorem ipsum. Code::
+    ClassWithDocumentation. Code::
 
         pass
 
@@ -21,7 +21,7 @@ class ClassWithoutDocumentation:
 
 def function_with_documentation() -> None:
     """
-    Lorem ipsum. Code::
+    function_with_documentation. Code::
 
         pass
 
@@ -34,7 +34,7 @@ def function_without_documentation() -> None:
 
 
 class ClassWithParameters:
-    """Lorem ipsum.
+    """ClassWithParameters.
 
     Dolor sit amet.
 
@@ -47,7 +47,7 @@ class ClassWithParameters:
 
 
 def function_with_parameters(no_type_no_default, type_no_default, with_default, *args, **kwargs) -> None:
-    """Lorem ipsum.
+    """function_with_parameters.
 
     Dolor sit amet.
 
@@ -61,7 +61,7 @@ def function_with_parameters(no_type_no_default, type_no_default, with_default, 
 
 
 def function_with_attributes_and_parameters(q) -> None:
-    """Lorem ipsum.
+    """function_with_attributes_and_parameters.
 
     Dolor sit amet.
 
@@ -74,7 +74,7 @@ def function_with_attributes_and_parameters(q) -> None:
 
 
 class ClassWithAttributes:
-    """Lorem ipsum.
+    """ClassWithAttributes.
 
     Dolor sit amet.
 
@@ -87,7 +87,7 @@ class ClassWithAttributes:
 
 
 def function_with_return_value_and_type() -> bool:
-    """Lorem ipsum.
+    """function_with_return_value_and_type.
 
     Dolor sit amet.
 
@@ -97,7 +97,7 @@ def function_with_return_value_and_type() -> bool:
 
 
 def function_with_return_value_no_type() -> None:
-    """Lorem ipsum.
+    """function_with_return_value_no_type.
 
     Dolor sit amet.
 
@@ -107,7 +107,7 @@ def function_with_return_value_no_type() -> None:
 
 
 def function_without_return_value():
-    """Lorem ipsum.
+    """function_without_return_value.
 
     Dolor sit amet.
     """
@@ -116,7 +116,7 @@ def function_without_return_value():
 class ClassWithMethod:
     def method_with_docstring(self, a) -> bool:
         """
-        Lorem ipsum.
+        method_with_docstring.
 
         Dolor sit amet.
 
@@ -130,7 +130,7 @@ class ClassWithMethod:
     @property
     def property_method_with_docstring(self) -> bool:
         """
-        Lorem ipsum.
+        property_method_with_docstring.
 
         Dolor sit amet.
 
@@ -141,7 +141,7 @@ class ClassWithMethod:
 
 class EnumDocstring(Enum):
     """
-    Lorem ipsum.
+    EnumDocstring.
 
     Dolor sit amet.
     """

--- a/tests/data/docstring_parser_package/googledoc.py
+++ b/tests/data/docstring_parser_package/googledoc.py
@@ -128,7 +128,7 @@ class ClassWithMethod:
         """
 
     @property
-    def property_method_with_docstring(self):
+    def property_method_with_docstring(self) -> bool:
         """
         Lorem ipsum.
 

--- a/tests/data/docstring_parser_package/googledoc.py
+++ b/tests/data/docstring_parser_package/googledoc.py
@@ -1,3 +1,10 @@
+"""Test module for docstring tests.
+
+A module for testing the various docstring types.
+"""
+from enum import Enum
+
+
 class ClassWithDocumentation:
     """
     Lorem ipsum. Code::
@@ -101,6 +108,40 @@ def function_with_return_value_no_type() -> None:
 
 def function_without_return_value():
     """Lorem ipsum.
+
+    Dolor sit amet.
+    """
+
+
+class ClassWithMethod:
+    def method_with_docstring(self, a) -> bool:
+        """
+        Lorem ipsum.
+
+        Dolor sit amet.
+
+        Args:
+            a (int): foo
+
+        Returns:
+            bool: this will be the return value.
+        """
+
+    @property
+    def property_method_with_docstring(self):
+        """
+        Lorem ipsum.
+
+        Dolor sit amet.
+
+        Returns:
+            bool: this will be the return value.
+        """
+
+
+class EnumDocstring(Enum):
+    """
+    Lorem ipsum.
 
     Dolor sit amet.
     """

--- a/tests/data/docstring_parser_package/googledoc.py
+++ b/tests/data/docstring_parser_package/googledoc.py
@@ -35,11 +35,11 @@ class ClassWithParameters:
         p (int): foo. Defaults to 1.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, p) -> None:
         pass
 
 
-def function_with_parameters() -> None:
+def function_with_parameters(no_type_no_default, type_no_default, with_default, *args, **kwargs) -> None:
     """Lorem ipsum.
 
     Dolor sit amet.
@@ -53,7 +53,7 @@ def function_with_parameters() -> None:
     """
 
 
-def function_with_attributes_and_parameters() -> None:
+def function_with_attributes_and_parameters(q) -> None:
     """Lorem ipsum.
 
     Dolor sit amet.
@@ -63,7 +63,6 @@ def function_with_attributes_and_parameters() -> None:
 
     Args:
         q (int): foo. Defaults to 2.
-
     """
 
 
@@ -74,16 +73,19 @@ class ClassWithAttributes:
 
     Attributes:
         p (int): foo. Defaults to 1.
+        q (int): foo. Defaults to 1.
     """
+    p: int
+    q = 1
 
 
-def function_with_return_value_and_type() -> None:
+def function_with_return_value_and_type() -> bool:
     """Lorem ipsum.
 
     Dolor sit amet.
 
     Returns:
-        int: this will be the return value.
+        bool: this will be the return value.
     """
 
 
@@ -93,11 +95,11 @@ def function_with_return_value_no_type() -> None:
     Dolor sit amet.
 
     Returns:
-        int
+        None
     """
 
 
-def function_without_return_value() -> None:
+def function_without_return_value():
     """Lorem ipsum.
 
     Dolor sit amet.

--- a/tests/data/docstring_parser_package/numpydoc.py
+++ b/tests/data/docstring_parser_package/numpydoc.py
@@ -1,3 +1,6 @@
+from typing import Any, Optional
+
+
 class ClassWithDocumentation:
     """
     Lorem ipsum. Code::
@@ -38,11 +41,14 @@ class ClassWithParameters:
         foo
     """
 
-    def __init__(self) -> None:
+    def __init__(self, p) -> None:
         pass
 
 
-def function_with_parameters() -> None:
+def function_with_parameters(
+    no_type_no_default, type_no_default, optional_unknown_default, with_default_syntax_1, with_default_syntax_2,
+    with_default_syntax_3, grouped_parameter_1, grouped_parameter_2, *args, **kwargs
+) -> None:
     """
     Lorem ipsum.
 
@@ -73,7 +79,7 @@ def function_with_parameters() -> None:
     """
 
 
-class ClassAndFunctionWithParameters:
+class ClassAndConstructorWithParameters:
     """
     Parameters
     ----------
@@ -102,16 +108,20 @@ class ClassWithParametersAndAttributes:
 
     Parameters
     ----------
-    p : int, default=1
+    x : int, default=1
         foo
 
     Attributes
     ----------
+    p : int, default=1
+        foo
     q : int, default=1
         foo
     """
+    p: int
+    q = 1
 
-    def __init__(self) -> None:
+    def __init__(self, x) -> None:
         pass
 
 
@@ -140,12 +150,19 @@ class ClassWithAttributes:
     grouped_attribute_1, grouped_attribute_2 : int, default=4
         foo: grouped_attribute_1 and grouped_attribute_2
     """
+    no_type_no_default: Any
+    type_no_default: int
+    optional_unknown_default: Optional[int]
+    with_default_syntax_1 = 1
+    with_default_syntax_2: int
+    with_default_syntax_3: int = 3
+    grouped_attribute_1, grouped_attribute_2 = 4, 4
 
     def __init__(self) -> None:
         pass
 
 
-def function_with_result_value_and_type() -> None:
+def function_with_result_value_and_type() -> bool:
     """
     Lorem ipsum.
 
@@ -153,12 +170,25 @@ def function_with_result_value_and_type() -> None:
 
     Returns
     -------
-    int
+    bool
         this will be the return value
     """
 
 
-def function_without_result_value() -> None:
+def function_with_named_result() -> bool:
+    """
+    Lorem ipsum.
+
+    Dolor sit amet.
+
+    Returns
+    -------
+    named_result : bool
+        this will be the return value
+    """
+
+
+def function_without_result_value():
     """
     Lorem ipsum.
 

--- a/tests/data/docstring_parser_package/numpydoc.py
+++ b/tests/data/docstring_parser_package/numpydoc.py
@@ -220,7 +220,7 @@ class ClassWithMethod:
         """
 
     @property
-    def property_method_with_docstring(self):
+    def property_method_with_docstring(self) -> bool:
         """
         Lorem ipsum.
 

--- a/tests/data/docstring_parser_package/numpydoc.py
+++ b/tests/data/docstring_parser_package/numpydoc.py
@@ -1,5 +1,5 @@
 """
-Test module for docstring tests.
+Test module for Numpy docstring tests.
 
 A module for testing the various docstring types.
 """
@@ -9,7 +9,7 @@ from enum import Enum
 
 class ClassWithDocumentation:
     """
-    Lorem ipsum. Code::
+    ClassWithDocumentation. Code::
 
         pass
 
@@ -23,7 +23,7 @@ class ClassWithoutDocumentation:
 
 def function_with_documentation() -> None:
     """
-    Lorem ipsum. Code::
+    function_with_documentation. Code::
 
         pass
 
@@ -37,7 +37,7 @@ def function_without_documentation() -> None:
 
 class ClassWithParameters:
     """
-    Lorem ipsum.
+    ClassWithParameters.
 
     Dolor sit amet.
 
@@ -56,7 +56,7 @@ def function_with_parameters(
     with_default_syntax_3, grouped_parameter_1, grouped_parameter_2, *args, **kwargs
 ) -> None:
     """
-    Lorem ipsum.
+    function_with_parameters.
 
     Dolor sit amet.
 
@@ -87,6 +87,10 @@ def function_with_parameters(
 
 class ClassAndConstructorWithParameters:
     """
+    ClassAndConstructorWithParameters
+
+    Dolor sit amet.
+
     Parameters
     ----------
     x: str
@@ -108,7 +112,7 @@ class ClassAndConstructorWithParameters:
 
 class ClassWithParametersAndAttributes:
     """
-    Lorem ipsum.
+    ClassWithParametersAndAttributes.
 
     Dolor sit amet.
 
@@ -133,7 +137,7 @@ class ClassWithParametersAndAttributes:
 
 class ClassWithAttributes:
     """
-    Lorem ipsum.
+    ClassWithAttributes.
 
     Dolor sit amet.
 
@@ -170,7 +174,7 @@ class ClassWithAttributes:
 
 def function_with_result_value_and_type() -> bool:
     """
-    Lorem ipsum.
+    function_with_result_value_and_type.
 
     Dolor sit amet.
 
@@ -183,7 +187,7 @@ def function_with_result_value_and_type() -> bool:
 
 def function_with_named_result() -> bool:
     """
-    Lorem ipsum.
+    function_with_named_result.
 
     Dolor sit amet.
 
@@ -196,7 +200,7 @@ def function_with_named_result() -> bool:
 
 def function_without_result_value():
     """
-    Lorem ipsum.
+    function_without_result_value.
 
     Dolor sit amet.
     """
@@ -205,7 +209,7 @@ def function_without_result_value():
 class ClassWithMethod:
     def method_with_docstring(self, a) -> bool:
         """
-        Lorem ipsum.
+        method_with_docstring.
 
         Dolor sit amet.
 
@@ -222,7 +226,7 @@ class ClassWithMethod:
     @property
     def property_method_with_docstring(self) -> bool:
         """
-        Lorem ipsum.
+        property_method_with_docstring.
 
         Dolor sit amet.
 
@@ -235,7 +239,7 @@ class ClassWithMethod:
 
 class EnumDocstring(Enum):
     """
-    Lorem ipsum.
+    EnumDocstring.
 
     Dolor sit amet.
     """

--- a/tests/data/docstring_parser_package/numpydoc.py
+++ b/tests/data/docstring_parser_package/numpydoc.py
@@ -1,4 +1,10 @@
+"""
+Test module for docstring tests.
+
+A module for testing the various docstring types.
+"""
 from typing import Any, Optional
+from enum import Enum
 
 
 class ClassWithDocumentation:
@@ -189,6 +195,45 @@ def function_with_named_result() -> bool:
 
 
 def function_without_result_value():
+    """
+    Lorem ipsum.
+
+    Dolor sit amet.
+    """
+
+
+class ClassWithMethod:
+    def method_with_docstring(self, a) -> bool:
+        """
+        Lorem ipsum.
+
+        Dolor sit amet.
+
+        Parameters
+        ----------
+        a: str
+
+        Returns
+        -------
+        named_result : bool
+            this will be the return value
+        """
+
+    @property
+    def property_method_with_docstring(self):
+        """
+        Lorem ipsum.
+
+        Dolor sit amet.
+
+        Returns
+        -------
+        named_result : bool
+            this will be the return value
+        """
+
+
+class EnumDocstring(Enum):
     """
     Lorem ipsum.
 

--- a/tests/data/docstring_parser_package/plaintext.py
+++ b/tests/data/docstring_parser_package/plaintext.py
@@ -1,3 +1,9 @@
+"""Test module for docstring tests.
+
+A module for testing the various docstring types.
+"""
+
+
 class ClassWithDocumentation:
     """
     Lorem ipsum.

--- a/tests/data/docstring_parser_package/plaintext.py
+++ b/tests/data/docstring_parser_package/plaintext.py
@@ -1,4 +1,4 @@
-"""Test module for docstring tests.
+"""Test module for plaintext docstring tests.
 
 A module for testing the various docstring types.
 """
@@ -6,7 +6,7 @@ A module for testing the various docstring types.
 
 class ClassWithDocumentation:
     """
-    Lorem ipsum.
+    ClassWithDocumentation.
 
     Dolor sit amet.
     """
@@ -21,7 +21,7 @@ class ClassWithoutDocumentation:
 
 def function_with_documentation(p: int) -> None:
     """
-    Lorem ipsum.
+    function_with_documentation.
 
     Dolor sit amet.
     """

--- a/tests/data/docstring_parser_package/restdoc.py
+++ b/tests/data/docstring_parser_package/restdoc.py
@@ -1,5 +1,5 @@
 """
-Test module for docstring tests.
+Test module for ReST docstring tests.
 
 A module for testing the various docstring types.
 """
@@ -8,7 +8,7 @@ from enum import Enum
 
 class ClassWithDocumentation:
     """
-    Lorem ipsum. Code::
+    ClassWithDocumentation. Code::
 
         pass
 
@@ -22,7 +22,7 @@ class ClassWithoutDocumentation:
 
 def function_with_documentation() -> None:
     """
-    Lorem ipsum. Code::
+    function_with_documentation. Code::
 
         pass
 
@@ -36,7 +36,7 @@ def function_without_documentation() -> None:
 
 class ClassWithParameters:
     """
-    Lorem ipsum.
+    ClassWithParameters.
 
     Dolor sit amet.
 
@@ -50,7 +50,7 @@ class ClassWithParameters:
 
 def function_with_parameters(no_type_no_default, type_no_default, with_default, *args, **kwargs) -> None:
     """
-    Lorem ipsum.
+    function_with_parameters.
 
     Dolor sit amet.
 
@@ -68,7 +68,7 @@ def function_with_parameters(no_type_no_default, type_no_default, with_default, 
 
 def function_with_return_value_and_type() -> bool:
     """
-    Lorem ipsum.
+    function_with_return_value_and_type.
 
     Dolor sit amet.
 
@@ -79,7 +79,7 @@ def function_with_return_value_and_type() -> bool:
 
 def function_with_return_value_no_type() -> None:
     """
-    Lorem ipsum.
+    function_with_return_value_no_type.
 
     Dolor sit amet.
 
@@ -89,7 +89,7 @@ def function_with_return_value_no_type() -> None:
 
 def function_without_return_value():
     """
-    Lorem ipsum.
+    function_without_return_value.
 
     Dolor sit amet.
     """
@@ -98,7 +98,7 @@ def function_without_return_value():
 class ClassWithMethod:
     def method_with_docstring(self, a) -> bool:
         """
-        Lorem ipsum.
+        method_with_docstring.
 
         Dolor sit amet.
 
@@ -112,7 +112,7 @@ class ClassWithMethod:
     @property
     def property_method_with_docstring(self) -> bool:
         """
-        Lorem ipsum.
+        property_method_with_docstring.
 
         Dolor sit amet.
 
@@ -123,7 +123,7 @@ class ClassWithMethod:
 
 class EnumDocstring(Enum):
     """
-    Lorem ipsum.
+    EnumDocstring.
 
     Dolor sit amet.
     """

--- a/tests/data/docstring_parser_package/restdoc.py
+++ b/tests/data/docstring_parser_package/restdoc.py
@@ -110,7 +110,7 @@ class ClassWithMethod:
         """
 
     @property
-    def property_method_with_docstring(self):
+    def property_method_with_docstring(self) -> bool:
         """
         Lorem ipsum.
 

--- a/tests/data/docstring_parser_package/restdoc.py
+++ b/tests/data/docstring_parser_package/restdoc.py
@@ -1,3 +1,11 @@
+"""
+Test module for docstring tests.
+
+A module for testing the various docstring types.
+"""
+from enum import Enum
+
+
 class ClassWithDocumentation:
     """
     Lorem ipsum. Code::
@@ -80,6 +88,40 @@ def function_with_return_value_no_type() -> None:
 
 
 def function_without_return_value():
+    """
+    Lorem ipsum.
+
+    Dolor sit amet.
+    """
+
+
+class ClassWithMethod:
+    def method_with_docstring(self, a) -> bool:
+        """
+        Lorem ipsum.
+
+        Dolor sit amet.
+
+        :param a: type but no default
+        :type a: int
+
+        :return: return value
+        :rtype: bool
+        """
+
+    @property
+    def property_method_with_docstring(self):
+        """
+        Lorem ipsum.
+
+        Dolor sit amet.
+
+        :return: return value
+        :rtype: bool
+        """
+
+
+class EnumDocstring(Enum):
     """
     Lorem ipsum.
 

--- a/tests/data/docstring_parser_package/restdoc.py
+++ b/tests/data/docstring_parser_package/restdoc.py
@@ -36,11 +36,11 @@ class ClassWithParameters:
     :type p: int
     """
 
-    def __init__(self) -> None:
+    def __init__(self, p) -> None:
         pass
 
 
-def function_with_parameters() -> None:
+def function_with_parameters(no_type_no_default, type_no_default, with_default, *args, **kwargs) -> None:
     """
     Lorem ipsum.
 
@@ -58,7 +58,7 @@ def function_with_parameters() -> None:
     """
 
 
-def function_with_return_value_and_type() -> None:
+def function_with_return_value_and_type() -> bool:
     """
     Lorem ipsum.
 
@@ -79,7 +79,7 @@ def function_with_return_value_no_type() -> None:
     """
 
 
-def function_without_return_value() -> None:
+def function_without_return_value():
     """
     Lorem ipsum.
 

--- a/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
+++ b/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
@@ -6573,7 +6573,7 @@
   list([
   ])
 # ---
-# name: test_modules[__init__0]
+# name: test_modules[__init__]
   dict({
     'classes': list([
     ]),
@@ -6630,122 +6630,6 @@
       dict({
         'module_name': '_reexport_module_3',
       }),
-    ]),
-  })
-# ---
-# name: test_modules[__init__1]
-  dict({
-    'classes': list([
-    ]),
-    'docstring': '',
-    'enums': list([
-    ]),
-    'functions': list([
-    ]),
-    'id': 'tests/data/various_modules_package/file_creation',
-    'name': '__init__',
-    'qualified_imports': list([
-      dict({
-        'alias': None,
-        'qualified_name': '_module_2._private_reexported',
-      }),
-      dict({
-        'alias': None,
-        'qualified_name': '_module_3.Reexported',
-      }),
-      dict({
-        'alias': None,
-        'qualified_name': '_module_6.public_reexported',
-      }),
-      dict({
-        'alias': None,
-        'qualified_name': 'tests.data.various_modules_package.another_path._reexported_from_another_package_2.ReexportedInAnotherPackageClass2',
-      }),
-      dict({
-        'alias': None,
-        'qualified_name': 'tests.data.various_modules_package.another_path._reexported_from_another_package_2.reexported_in_another_package_function2',
-      }),
-      dict({
-        'alias': 'reexported_from_another_package_3',
-        'qualified_name': 'tests.data.various_modules_package.another_path._reexported_from_another_package_3',
-      }),
-    ]),
-    'wildcard_imports': list([
-      dict({
-        'module_name': 'tests.data.various_modules_package.another_path._reexported_from_another_package',
-      }),
-    ]),
-  })
-# ---
-# name: test_modules[_module_2]
-  dict({
-    'classes': list([
-    ]),
-    'docstring': '',
-    'enums': list([
-    ]),
-    'functions': list([
-      'tests/data/various_modules_package/file_creation/_module_2/_private_reexported',
-    ]),
-    'id': 'tests/data/various_modules_package/file_creation/_module_2',
-    'name': '_module_2',
-    'qualified_imports': list([
-    ]),
-    'wildcard_imports': list([
-    ]),
-  })
-# ---
-# name: test_modules[_module_3]
-  dict({
-    'classes': list([
-      'tests/data/various_modules_package/file_creation/_module_3/Reexported',
-    ]),
-    'docstring': '',
-    'enums': list([
-    ]),
-    'functions': list([
-    ]),
-    'id': 'tests/data/various_modules_package/file_creation/_module_3',
-    'name': '_module_3',
-    'qualified_imports': list([
-    ]),
-    'wildcard_imports': list([
-    ]),
-  })
-# ---
-# name: test_modules[_module_4]
-  dict({
-    'classes': list([
-      'tests/data/various_modules_package/file_creation/_module_4/_Private',
-    ]),
-    'docstring': '',
-    'enums': list([
-    ]),
-    'functions': list([
-    ]),
-    'id': 'tests/data/various_modules_package/file_creation/_module_4',
-    'name': '_module_4',
-    'qualified_imports': list([
-    ]),
-    'wildcard_imports': list([
-    ]),
-  })
-# ---
-# name: test_modules[_module_6]
-  dict({
-    'classes': list([
-    ]),
-    'docstring': '',
-    'enums': list([
-    ]),
-    'functions': list([
-      'tests/data/various_modules_package/file_creation/_module_6/public_reexported',
-    ]),
-    'id': 'tests/data/various_modules_package/file_creation/_module_6',
-    'name': '_module_6',
-    'qualified_imports': list([
-    ]),
-    'wildcard_imports': list([
     ]),
   })
 # ---
@@ -6846,66 +6730,6 @@
     ]),
   })
 # ---
-# name: test_modules[_reexported_from_another_package]
-  dict({
-    'classes': list([
-      'tests/data/various_modules_package/another_path/_reexported_from_another_package/ReexportedInAnotherPackageClass',
-    ]),
-    'docstring': '',
-    'enums': list([
-    ]),
-    'functions': list([
-      'tests/data/various_modules_package/another_path/_reexported_from_another_package/reexported_in_another_package_function',
-      'tests/data/various_modules_package/another_path/_reexported_from_another_package/_still_internal_function',
-    ]),
-    'id': 'tests/data/various_modules_package/another_path/_reexported_from_another_package',
-    'name': '_reexported_from_another_package',
-    'qualified_imports': list([
-    ]),
-    'wildcard_imports': list([
-    ]),
-  })
-# ---
-# name: test_modules[_reexported_from_another_package_2]
-  dict({
-    'classes': list([
-      'tests/data/various_modules_package/another_path/_reexported_from_another_package_2/ReexportedInAnotherPackageClass2',
-    ]),
-    'docstring': '',
-    'enums': list([
-    ]),
-    'functions': list([
-      'tests/data/various_modules_package/another_path/_reexported_from_another_package_2/reexported_in_another_package_function2',
-      'tests/data/various_modules_package/another_path/_reexported_from_another_package_2/_still_internal_function2',
-    ]),
-    'id': 'tests/data/various_modules_package/another_path/_reexported_from_another_package_2',
-    'name': '_reexported_from_another_package_2',
-    'qualified_imports': list([
-    ]),
-    'wildcard_imports': list([
-    ]),
-  })
-# ---
-# name: test_modules[_reexported_from_another_package_3]
-  dict({
-    'classes': list([
-      'tests/data/various_modules_package/another_path/_reexported_from_another_package_3/ReexportedInAnotherPackageClass3',
-    ]),
-    'docstring': '',
-    'enums': list([
-    ]),
-    'functions': list([
-      'tests/data/various_modules_package/another_path/_reexported_from_another_package_3/reexported_in_another_package_function3',
-      'tests/data/various_modules_package/another_path/_reexported_from_another_package_3/_still_internal_function3',
-    ]),
-    'id': 'tests/data/various_modules_package/another_path/_reexported_from_another_package_3',
-    'name': '_reexported_from_another_package_3',
-    'qualified_imports': list([
-    ]),
-    'wildcard_imports': list([
-    ]),
-  })
-# ---
 # name: test_modules[abstract_module]
   dict({
     'classes': list([
@@ -6932,7 +6756,7 @@
     ]),
   })
 # ---
-# name: test_modules[aliasing_module_1]
+# name: test_modules[aliasing/aliasing_module_1]
   dict({
     'classes': list([
       'tests/data/various_modules_package/aliasing/aliasing_module_1/_AliasingModuleClassA',
@@ -6960,7 +6784,7 @@
     ]),
   })
 # ---
-# name: test_modules[aliasing_module_2]
+# name: test_modules[aliasing/aliasing_module_2]
   dict({
     'classes': list([
       'tests/data/various_modules_package/aliasing/aliasing_module_2/AliasingModule2ClassA',
@@ -6985,7 +6809,7 @@
     ]),
   })
 # ---
-# name: test_modules[aliasing_module_3]
+# name: test_modules[aliasing/aliasing_module_3]
   dict({
     'classes': list([
       'tests/data/various_modules_package/aliasing/aliasing_module_3/ImportMeAliasingModuleClass',
@@ -7007,7 +6831,67 @@
     ]),
   })
 # ---
-# name: test_modules[another_module]
+# name: test_modules[another_path/_reexported_from_another_package]
+  dict({
+    'classes': list([
+      'tests/data/various_modules_package/another_path/_reexported_from_another_package/ReexportedInAnotherPackageClass',
+    ]),
+    'docstring': '',
+    'enums': list([
+    ]),
+    'functions': list([
+      'tests/data/various_modules_package/another_path/_reexported_from_another_package/reexported_in_another_package_function',
+      'tests/data/various_modules_package/another_path/_reexported_from_another_package/_still_internal_function',
+    ]),
+    'id': 'tests/data/various_modules_package/another_path/_reexported_from_another_package',
+    'name': '_reexported_from_another_package',
+    'qualified_imports': list([
+    ]),
+    'wildcard_imports': list([
+    ]),
+  })
+# ---
+# name: test_modules[another_path/_reexported_from_another_package_2]
+  dict({
+    'classes': list([
+      'tests/data/various_modules_package/another_path/_reexported_from_another_package_2/ReexportedInAnotherPackageClass2',
+    ]),
+    'docstring': '',
+    'enums': list([
+    ]),
+    'functions': list([
+      'tests/data/various_modules_package/another_path/_reexported_from_another_package_2/reexported_in_another_package_function2',
+      'tests/data/various_modules_package/another_path/_reexported_from_another_package_2/_still_internal_function2',
+    ]),
+    'id': 'tests/data/various_modules_package/another_path/_reexported_from_another_package_2',
+    'name': '_reexported_from_another_package_2',
+    'qualified_imports': list([
+    ]),
+    'wildcard_imports': list([
+    ]),
+  })
+# ---
+# name: test_modules[another_path/_reexported_from_another_package_3]
+  dict({
+    'classes': list([
+      'tests/data/various_modules_package/another_path/_reexported_from_another_package_3/ReexportedInAnotherPackageClass3',
+    ]),
+    'docstring': '',
+    'enums': list([
+    ]),
+    'functions': list([
+      'tests/data/various_modules_package/another_path/_reexported_from_another_package_3/reexported_in_another_package_function3',
+      'tests/data/various_modules_package/another_path/_reexported_from_another_package_3/_still_internal_function3',
+    ]),
+    'id': 'tests/data/various_modules_package/another_path/_reexported_from_another_package_3',
+    'name': '_reexported_from_another_package_3',
+    'qualified_imports': list([
+    ]),
+    'wildcard_imports': list([
+    ]),
+  })
+# ---
+# name: test_modules[another_path/another_module]
   dict({
     'classes': list([
       'tests/data/various_modules_package/another_path/another_module/AnotherClass',
@@ -7152,6 +7036,158 @@
         'alias': '_AcImportAlias',
         'qualified_name': 'another_path.another_module.AnotherClass',
       }),
+    ]),
+    'wildcard_imports': list([
+    ]),
+  })
+# ---
+# name: test_modules[file_creation/__init__]
+  dict({
+    'classes': list([
+    ]),
+    'docstring': '',
+    'enums': list([
+    ]),
+    'functions': list([
+    ]),
+    'id': 'tests/data/various_modules_package/file_creation',
+    'name': '__init__',
+    'qualified_imports': list([
+      dict({
+        'alias': None,
+        'qualified_name': '_module_2._private_reexported',
+      }),
+      dict({
+        'alias': None,
+        'qualified_name': '_module_3.Reexported',
+      }),
+      dict({
+        'alias': None,
+        'qualified_name': '_module_6.public_reexported',
+      }),
+      dict({
+        'alias': None,
+        'qualified_name': 'tests.data.various_modules_package.another_path._reexported_from_another_package_2.ReexportedInAnotherPackageClass2',
+      }),
+      dict({
+        'alias': None,
+        'qualified_name': 'tests.data.various_modules_package.another_path._reexported_from_another_package_2.reexported_in_another_package_function2',
+      }),
+      dict({
+        'alias': 'reexported_from_another_package_3',
+        'qualified_name': 'tests.data.various_modules_package.another_path._reexported_from_another_package_3',
+      }),
+    ]),
+    'wildcard_imports': list([
+      dict({
+        'module_name': 'tests.data.various_modules_package.another_path._reexported_from_another_package',
+      }),
+    ]),
+  })
+# ---
+# name: test_modules[file_creation/_module_2]
+  dict({
+    'classes': list([
+    ]),
+    'docstring': '',
+    'enums': list([
+    ]),
+    'functions': list([
+      'tests/data/various_modules_package/file_creation/_module_2/_private_reexported',
+    ]),
+    'id': 'tests/data/various_modules_package/file_creation/_module_2',
+    'name': '_module_2',
+    'qualified_imports': list([
+    ]),
+    'wildcard_imports': list([
+    ]),
+  })
+# ---
+# name: test_modules[file_creation/_module_3]
+  dict({
+    'classes': list([
+      'tests/data/various_modules_package/file_creation/_module_3/Reexported',
+    ]),
+    'docstring': '',
+    'enums': list([
+    ]),
+    'functions': list([
+    ]),
+    'id': 'tests/data/various_modules_package/file_creation/_module_3',
+    'name': '_module_3',
+    'qualified_imports': list([
+    ]),
+    'wildcard_imports': list([
+    ]),
+  })
+# ---
+# name: test_modules[file_creation/_module_4]
+  dict({
+    'classes': list([
+      'tests/data/various_modules_package/file_creation/_module_4/_Private',
+    ]),
+    'docstring': '',
+    'enums': list([
+    ]),
+    'functions': list([
+    ]),
+    'id': 'tests/data/various_modules_package/file_creation/_module_4',
+    'name': '_module_4',
+    'qualified_imports': list([
+    ]),
+    'wildcard_imports': list([
+    ]),
+  })
+# ---
+# name: test_modules[file_creation/_module_6]
+  dict({
+    'classes': list([
+    ]),
+    'docstring': '',
+    'enums': list([
+    ]),
+    'functions': list([
+      'tests/data/various_modules_package/file_creation/_module_6/public_reexported',
+    ]),
+    'id': 'tests/data/various_modules_package/file_creation/_module_6',
+    'name': '_module_6',
+    'qualified_imports': list([
+    ]),
+    'wildcard_imports': list([
+    ]),
+  })
+# ---
+# name: test_modules[file_creation/module_1]
+  dict({
+    'classes': list([
+      'tests/data/various_modules_package/file_creation/module_1/C',
+    ]),
+    'docstring': '',
+    'enums': list([
+    ]),
+    'functions': list([
+    ]),
+    'id': 'tests/data/various_modules_package/file_creation/module_1',
+    'name': 'module_1',
+    'qualified_imports': list([
+    ]),
+    'wildcard_imports': list([
+    ]),
+  })
+# ---
+# name: test_modules[file_creation/package_1/module_5]
+  dict({
+    'classes': list([
+      'tests/data/various_modules_package/file_creation/package_1/module_5/C',
+    ]),
+    'docstring': '',
+    'enums': list([
+    ]),
+    'functions': list([
+    ]),
+    'id': 'tests/data/various_modules_package/file_creation/package_1/module_5',
+    'name': 'module_5',
+    'qualified_imports': list([
     ]),
     'wildcard_imports': list([
     ]),
@@ -7311,42 +7347,6 @@
     ]),
     'id': 'tests/data/various_modules_package/inheritance_module',
     'name': 'inheritance_module',
-    'qualified_imports': list([
-    ]),
-    'wildcard_imports': list([
-    ]),
-  })
-# ---
-# name: test_modules[module_1]
-  dict({
-    'classes': list([
-      'tests/data/various_modules_package/file_creation/module_1/C',
-    ]),
-    'docstring': '',
-    'enums': list([
-    ]),
-    'functions': list([
-    ]),
-    'id': 'tests/data/various_modules_package/file_creation/module_1',
-    'name': 'module_1',
-    'qualified_imports': list([
-    ]),
-    'wildcard_imports': list([
-    ]),
-  })
-# ---
-# name: test_modules[module_5]
-  dict({
-    'classes': list([
-      'tests/data/various_modules_package/file_creation/package_1/module_5/C',
-    ]),
-    'docstring': '',
-    'enums': list([
-    ]),
-    'functions': list([
-    ]),
-    'id': 'tests/data/various_modules_package/file_creation/package_1/module_5',
-    'name': 'module_5',
     'qualified_imports': list([
     ]),
     'wildcard_imports': list([

--- a/tests/safeds_stubgen/api_analyzer/test__get_api.py
+++ b/tests/safeds_stubgen/api_analyzer/test__get_api.py
@@ -59,7 +59,7 @@ def _get_specific_module_data(module_name: str, docstring_style: str = "plaintex
     for module in api_data["modules"]:
         if module["name"] == module_name:
             return module
-    raise AssertionError
+    raise pytest.fail(f"Could not find module data for '{module_name}'.")
 
 
 def _get_specific_class_data(
@@ -73,7 +73,7 @@ def _get_specific_class_data(
     for class_ in api_data[data_type]:
         if module_name in class_["id"] and class_["id"].endswith(f"/{class_name}"):
             return class_
-    raise AssertionError
+    raise pytest.fail(f"Could not find class data for '{class_name}' in module '{module_name}'.")
 
 
 def get_api_data(docstring_style: str) -> dict:
@@ -100,7 +100,7 @@ def _get_specific_function_data(
     for function in api_data["functions"]:
         if function["id"].endswith(f"{parent_class_name}/{function_name}"):
             return function
-    raise AssertionError
+    raise pytest.fail(f"Could not find function data for '{function_name}' in module '{module_name}'.")
 
 
 _function_module_name = "function_module"
@@ -144,7 +144,7 @@ def test_modules(python_file: Path, snapshot: SnapshotAssertion) -> None:
         if is_init_file or is_module_file:
             assert module == snapshot
             return
-    raise AssertionError
+    raise pytest.fail(f"Could not find module data for '{file_name}'.")
 
 
 # Todo new tests after issue #38

--- a/tests/safeds_stubgen/api_analyzer/test__get_api.py
+++ b/tests/safeds_stubgen/api_analyzer/test__get_api.py
@@ -140,7 +140,7 @@ def test_modules(python_file: Path, snapshot: SnapshotAssertion) -> None:
 
     for module in api_data["modules"]:
         is_init_file = is_package and module_id.endswith(module["id"])
-        is_module_file = str(python_file).replace("\\", "/").endswith(f"{module['id']}.py")
+        is_module_file = "/".join(python_file.parts).endswith(f"{module['id']}.py")
         if is_init_file or is_module_file:
             assert module == snapshot
             return

--- a/tests/safeds_stubgen/api_analyzer/test__get_api.py
+++ b/tests/safeds_stubgen/api_analyzer/test__get_api.py
@@ -121,7 +121,7 @@ def _python_files() -> Generator:
 def _python_file_ids() -> Generator:
     files = package_root.rglob(pattern="*.py")
     for file in files:
-        yield file.parts[-1].split(".py")[0]
+        yield str(file.relative_to(package_root).as_posix()).removesuffix(".py")
 
 
 @pytest.mark.parametrize("python_file", _python_files(), ids=_python_file_ids())

--- a/tests/safeds_stubgen/docstring_parsing/test_epydoc_parser.py
+++ b/tests/safeds_stubgen/docstring_parsing/test_epydoc_parser.py
@@ -270,7 +270,7 @@ def xtest_get_attribute_documentation(
     [
         (
             "function_with_result_value_and_type",
-            ResultDocstring(type="float", description="return value"),
+            ResultDocstring(type="bool", description="return value"),
         ),
         (
             "function_with_result_value_no_type",

--- a/tests/safeds_stubgen/docstring_parsing/test_get_full_docstring.py
+++ b/tests/safeds_stubgen/docstring_parsing/test_get_full_docstring.py
@@ -29,11 +29,11 @@ mypy_file = _get_mypy_asts(
     [
         (
             "ClassWithMultiLineDocumentation",
-            "Lorem ipsum.\n\nDolor sit amet.",
+            "ClassWithMultiLineDocumentation.\n\nDolor sit amet.",
         ),
         (
             "ClassWithSingleLineDocumentation",
-            "Lorem ipsum.",
+            "ClassWithSingleLineDocumentation.",
         ),
         (
             "ClassWithoutDocumentation",
@@ -41,11 +41,11 @@ mypy_file = _get_mypy_asts(
         ),
         (
             "function_with_multi_line_documentation",
-            "Lorem ipsum.\n\nDolor sit amet.",
+            "function_with_multi_line_documentation.\n\nDolor sit amet.",
         ),
         (
             "function_with_single_line_documentation",
-            "Lorem ipsum.",
+            "function_with_single_line_documentation.",
         ),
         (
             "function_without_documentation",

--- a/tests/safeds_stubgen/docstring_parsing/test_googledoc_parser.py
+++ b/tests/safeds_stubgen/docstring_parsing/test_googledoc_parser.py
@@ -319,11 +319,11 @@ def test_get_attribute_documentation(
     [
         (
             "function_with_return_value_and_type",
-            ResultDocstring(type="int", description="this will be the return value."),
+            ResultDocstring(type="bool", description="this will be the return value."),
         ),
         (
             "function_with_return_value_no_type",
-            ResultDocstring(type="", description="int"),
+            ResultDocstring(type="", description="None"),
         ),
         ("function_without_return_value", ResultDocstring(type="", description="")),
     ],

--- a/tests/safeds_stubgen/docstring_parsing/test_googledoc_parser.py
+++ b/tests/safeds_stubgen/docstring_parsing/test_googledoc_parser.py
@@ -44,8 +44,8 @@ def googlestyledoc_parser() -> GoogleDocParser:
         (
             "ClassWithDocumentation",
             ClassDocstring(
-                description="Lorem ipsum. Code::\n\npass\n\nDolor sit amet.",
-                full_docstring="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
+                description="ClassWithDocumentation. Code::\n\npass\n\nDolor sit amet.",
+                full_docstring="ClassWithDocumentation. Code::\n\n    pass\n\nDolor sit amet.",
             ),
         ),
         (
@@ -79,8 +79,8 @@ def test_get_class_documentation(
         (
             "function_with_documentation",
             FunctionDocstring(
-                description="Lorem ipsum. Code::\n\npass\n\nDolor sit amet.",
-                full_docstring="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
+                description="function_with_documentation. Code::\n\npass\n\nDolor sit amet.",
+                full_docstring="function_with_documentation. Code::\n\n    pass\n\nDolor sit amet.",
             ),
         ),
         (

--- a/tests/safeds_stubgen/docstring_parsing/test_numpydoc_parser.py
+++ b/tests/safeds_stubgen/docstring_parsing/test_numpydoc_parser.py
@@ -45,8 +45,8 @@ def numpydoc_parser() -> NumpyDocParser:
         (
             "ClassWithDocumentation",
             ClassDocstring(
-                description="Lorem ipsum. Code::\n\npass\n\nDolor sit amet.",
-                full_docstring="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
+                description="ClassWithDocumentation. Code::\n\npass\n\nDolor sit amet.",
+                full_docstring="ClassWithDocumentation. Code::\n\n    pass\n\nDolor sit amet.",
             ),
         ),
         (
@@ -80,8 +80,8 @@ def test_get_class_documentation(
         (
             "function_with_documentation",
             FunctionDocstring(
-                description="Lorem ipsum. Code::\n\npass\n\nDolor sit amet.",
-                full_docstring="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
+                description="function_with_documentation. Code::\n\npass\n\nDolor sit amet.",
+                full_docstring="function_with_documentation. Code::\n\n    pass\n\nDolor sit amet.",
             ),
         ),
         (

--- a/tests/safeds_stubgen/docstring_parsing/test_numpydoc_parser.py
+++ b/tests/safeds_stubgen/docstring_parsing/test_numpydoc_parser.py
@@ -244,7 +244,7 @@ def test_get_function_documentation(
             ParameterDocstring(type="", default_value="", description=""),
         ),
         (
-            "ClassAndFunctionWithParameters",
+            "ClassAndConstructorWithParameters",
             True,
             "x",
             ParameterAssignment.POSITION_OR_NAME,
@@ -255,7 +255,7 @@ def test_get_function_documentation(
             ),
         ),
         (
-            "ClassAndFunctionWithParameters",
+            "ClassAndConstructorWithParameters",
             True,
             "y",
             ParameterAssignment.POSITION_OR_NAME,
@@ -266,7 +266,7 @@ def test_get_function_documentation(
             ),
         ),
         (
-            "ClassAndFunctionWithParameters",
+            "ClassAndConstructorWithParameters",
             True,
             "z",
             ParameterAssignment.POSITION_OR_NAME,
@@ -279,7 +279,7 @@ def test_get_function_documentation(
         (
             "ClassWithParametersAndAttributes",
             True,
-            "p",
+            "x",
             ParameterAssignment.POSITION_OR_NAME,
             ParameterDocstring(
                 type="int",
@@ -430,7 +430,7 @@ def test_get_parameter_documentation(
         ),
         (
             "ClassWithParametersAndAttributes",
-            "p",
+            "r",
             AttributeDocstring(
                 type="",
                 default_value="",
@@ -486,7 +486,7 @@ def test_get_attribute_documentation(
     [
         (
             "function_with_result_value_and_type",
-            ResultDocstring(type="int", description="this will be the return value"),
+            ResultDocstring(type="bool", description="this will be the return value"),
         ),
         ("function_without_result_value", ResultDocstring(type="", description="")),
     ],

--- a/tests/safeds_stubgen/docstring_parsing/test_plaintext_docstring_parser.py
+++ b/tests/safeds_stubgen/docstring_parsing/test_plaintext_docstring_parser.py
@@ -43,8 +43,8 @@ def plaintext_docstring_parser() -> PlaintextDocstringParser:
         (
             "ClassWithDocumentation",
             ClassDocstring(
-                description="Lorem ipsum.\n\nDolor sit amet.",
-                full_docstring="Lorem ipsum.\n\nDolor sit amet.",
+                description="ClassWithDocumentation.\n\nDolor sit amet.",
+                full_docstring="ClassWithDocumentation.\n\nDolor sit amet.",
             ),
         ),
         (
@@ -78,8 +78,8 @@ def test_get_class_documentation(
         (
             "function_with_documentation",
             FunctionDocstring(
-                description="Lorem ipsum.\n\nDolor sit amet.",
-                full_docstring="Lorem ipsum.\n\nDolor sit amet.",
+                description="function_with_documentation.\n\nDolor sit amet.",
+                full_docstring="function_with_documentation.\n\nDolor sit amet.",
             ),
         ),
         (

--- a/tests/safeds_stubgen/docstring_parsing/test_restdoc_parser.py
+++ b/tests/safeds_stubgen/docstring_parsing/test_restdoc_parser.py
@@ -41,8 +41,8 @@ def restdoc_parser() -> RestDocParser:
         (
             "ClassWithDocumentation",
             ClassDocstring(
-                description="Lorem ipsum. Code::\n\npass\n\nDolor sit amet.",
-                full_docstring="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
+                description="ClassWithDocumentation. Code::\n\npass\n\nDolor sit amet.",
+                full_docstring="ClassWithDocumentation. Code::\n\n    pass\n\nDolor sit amet.",
             ),
         ),
         (
@@ -76,8 +76,8 @@ def test_get_class_documentation(
         (
             "function_with_documentation",
             FunctionDocstring(
-                description="Lorem ipsum. Code::\n\npass\n\nDolor sit amet.",
-                full_docstring="Lorem ipsum. Code::\n\n    pass\n\nDolor sit amet.",
+                description="function_with_documentation. Code::\n\npass\n\nDolor sit amet.",
+                full_docstring="function_with_documentation. Code::\n\n    pass\n\nDolor sit amet.",
             ),
         ),
         (

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[another_module].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[another_module].sdsstub
@@ -1,3 +1,9 @@
+/**
+ * Another Module Docstring.
+ * 
+ * Full Docstring Description
+ */
+
 @PythonModule("tests.data.various_modules_package.another_path.another_module")
 package tests.data.variousModulesPackage.anotherPath.anotherModule
 

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[docstring_module].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[docstring_module].sdsstub
@@ -1,12 +1,36 @@
+/**
+ * Test module for docstring tests.
+ * 
+ * A module for testing the various docstring types.
+ */
+
 @PythonModule("tests.data.various_modules_package.docstring_module")
 package tests.data.variousModulesPackage.docstringModule
 
+/**
+ * A class with a variety of different methods for calculations. (Epydoc).
+ * 
+ * @ivar attr_1: Attribute of the calculator. (Epydoc)
+ * @type attr_1: str
+ * @param param_1: Parameter of the calculator. (Epydoc)
+ * @type param_1: str
+ */
 class EpydocDocstringClass(
 	@PythonName("param_1") param1: String
 ) {
 	@PythonName("attr_1")
 	static attr attr1: String
 
+	/**
+	 * This function checks if the sum of x and y is less than the value 10 and returns True if it is. (Epydoc).
+	 * 
+	 * @param x: First integer value for the calculation. (Epydoc)
+	 * @type x: int
+	 * @param y: Second integer value for the calculation. (Epydoc)
+	 * @type y: int
+	 * @return: Checks if the sum of x and y is greater than 10. (Epydoc)
+	 * @rtype: bool
+	 */
 	@Pure
 	@PythonName("epydoc_docstring_func")
 	fun epydocDocstringFunc(
@@ -15,12 +39,31 @@ class EpydocDocstringClass(
 	) -> result1: Boolean
 }
 
+/**
+ * A class with a variety of different methods for calculations. (ReST).
+ * 
+ * :param attr_1: Attribute of the calculator. (ReST)
+ * :type attr_1: str
+ * :param param_1: Parameter of the calculator. (ReST)
+ * :type param_1: str
+ */
 class RestDocstringClass(
 	@PythonName("param_1") param1: String
 ) {
 	@PythonName("attr_1")
 	static attr attr1: String
 
+	/**
+	 * This function checks if the sum of x and y is less than the value 10
+	 * and returns True if it is. (ReST).
+	 * 
+	 * :param x: First integer value for the calculation. (ReST)
+	 * :type x: int
+	 * :param y: Second integer value for the calculation. (ReST)
+	 * :type y: int
+	 * :returns: Checks if the sum of x and y is greater than 10. (ReST)
+	 * :rtype: bool
+	 */
 	@Pure
 	@PythonName("rest_docstring_func")
 	fun restDocstringFunc(
@@ -29,12 +72,44 @@ class RestDocstringClass(
 	) -> result1: Boolean
 }
 
+/**
+ * A class that calculates stuff. (Numpy).
+ * 
+ * A class with a variety of different methods for calculations. (Numpy)
+ * 
+ * Attributes
+ * ----------
+ * attr_1 : str
+ *     Attribute of the calculator. (Numpy)
+ * 
+ * Parameters
+ * ----------
+ * param_1 : str
+ *     Parameter of the calculator. (Numpy)
+ */
 class NumpyDocstringClass(
 	@PythonName("param_1") param1: String
 ) {
 	@PythonName("attr_1")
 	static attr attr1: String
 
+	/**
+	 * Checks if the sum of two variables is over the value of 10. (Numpy).
+	 * 
+	 * This function checks if the sum of `x` and `y` is less than the value 10 and returns True if it is. (Numpy)
+	 * 
+	 * Parameters
+	 * ----------
+	 * x : int
+	 *     First integer value for the calculation. (Numpy)
+	 * y : int
+	 *     Second integer value for the calculation. (Numpy)
+	 * 
+	 * Returns
+	 * -------
+	 * bool
+	 *     Checks if the sum of `x` and `y` is greater than 10. (Numpy)
+	 */
 	@Pure
 	@PythonName("numpy_docstring_func")
 	fun numpyDocstringFunc(
@@ -43,12 +118,37 @@ class NumpyDocstringClass(
 	) -> result1: Boolean
 }
 
+/**
+ * A class that calculates stuff. (Google Style).
+ * 
+ * A class with a variety of different methods for calculations. (Google Style)
+ * 
+ * Attributes:
+ *     attr_1 (str): Attribute of the calculator. (Google Style)
+ * 
+ * Args:
+ *     param_1 (str): Parameter of the calculator. (Google Style)
+ */
 class GoogleDocstringClass(
 	@PythonName("param_1") param1: String
 ) {
 	@PythonName("attr_1")
 	static attr attr1: String
 
+	/**
+	 * Checks if the sum of two variables is over the value of 10. (Google Style).
+	 * 
+	 * This function checks if the sum of x and y is less than the value 10
+	 * and returns True if it is. (Google Style)
+	 * 
+	 * Args:
+	 *     x (int): First integer value for the calculation. (Google Style)
+	 *     y (int): Second integer value for the calculation. (Google Style)
+	 * 
+	 * Returns:
+	 *     bool: Checks if the sum of x and y is greater than 10 and returns
+	 *           a boolean value. (Google Style)
+	 */
 	@Pure
 	@PythonName("google_docstring_func")
 	fun googleDocstringFunc(

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[enum_module].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[enum_module].sdsstub
@@ -1,8 +1,16 @@
 @PythonModule("tests.data.various_modules_package")
 package tests.data.variousModulesPackage
 
+/**
+ * Nothing's here.
+ */
 enum _ReexportedEmptyEnum
 
+/**
+ * Enum Docstring.
+ * 
+ * Full Docstring Description
+ */
 enum EnumTest {
 	ONE
 	TWO

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[infer_types_module].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[infer_types_module].sdsstub
@@ -53,6 +53,9 @@ class InferMyTypes(
 		@PythonName("infer_param_2") inferParam2: Int = "Something"
 	) -> (result1: union<Boolean, Float, InferMe, InferMe2, InferMe3, InferMyTypes, Int, Nothing?, String>, result2: union<Float, Int>, result3: Float)
 
+	/**
+	 * Test for inferring results with just one possible result, and not a tuple of results.
+	 */
 	@Pure
 	@PythonName("infer_function_2")
 	static fun inferFunction2(

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[epydoc-EPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[epydoc-EPYDOC].sdsstub
@@ -32,9 +32,9 @@ fun functionWithoutDocumentation()
  * 
  * Dolor sit amet.
  *
- * @param no_type_no_default no type and no default
- * @param type_no_default type but no default
- * @param with_default foo that defaults to 2
+ * @param noTypeNoDefault no type and no default
+ * @param typeNoDefault type but no default
+ * @param withDefault foo that defaults to 2
  */
 @Pure
 @PythonName("function_with_parameters")
@@ -51,7 +51,7 @@ fun functionWithParameters(
  * 
  * Dolor sit amet.
  *
- * @result result_1 return value
+ * @result result1 return value
  */
 @Pure
 @PythonName("function_with_result_value_and_type")
@@ -126,7 +126,7 @@ class ClassWithMethod() {
 	 * 
 	 * Dolor sit amet.
 	 *
-	 * @result result_1 return value
+	 * @result result1 return value
 	 */
 	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring: Boolean
 
@@ -138,7 +138,7 @@ class ClassWithMethod() {
 	 *
 	 * @param a type but no default
 	 *
-	 * @result result_1 return value
+	 * @result result1 return value
 	 */
 	@Pure
 	@PythonName("method_with_docstring")

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[epydoc-EPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[epydoc-EPYDOC].sdsstub
@@ -1,0 +1,58 @@
+@PythonModule("tests.data.docstring_parser_package.epydoc")
+package tests.data.docstringParserPackage.epydoc
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_with_documentation")
+fun functionWithDocumentation()
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_without_documentation")
+fun functionWithoutDocumentation()
+
+// TODO Result type information missing.
+// TODO Safe-DS does not support variadic parameters.
+// TODO Some parameter have no type information.
+@Pure
+@PythonName("function_with_parameters")
+fun functionWithParameters(
+	@PythonName("no_type_no_default") noTypeNoDefault,
+	@PythonName("type_no_default") typeNoDefault,
+	@PythonName("with_default") withDefault,
+	args: List<Any>,
+	kwargs: Map<String, Any>
+)
+
+@Pure
+@PythonName("function_with_result_value_and_type")
+fun functionWithResultValueAndType() -> result1: Boolean
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_with_result_value_no_type")
+fun functionWithResultValueNoType()
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_without_result_value")
+fun functionWithoutResultValue()
+
+class ClassWithDocumentation()
+
+class ClassWithoutDocumentation()
+
+// TODO Some parameter have no type information.
+class ClassWithParameters(
+	p
+)
+
+class ClassWithAttributes() {
+	static attr p: Int
+	static attr q: Int
+}
+
+class ClassWithAttributesNoType() {
+	static attr p: Int
+	static attr q: Int
+}

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[epydoc-EPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[epydoc-EPYDOC].sdsstub
@@ -125,8 +125,6 @@ class ClassWithMethod() {
 	 * Lorem ipsum.
 	 * 
 	 * Dolor sit amet.
-	 *
-	 * @result result1 return value
 	 */
 	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring: Boolean
 

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[epydoc-EPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[epydoc-EPYDOC].sdsstub
@@ -1,5 +1,4 @@
 /**
- * 
  * Test module for docstring tests.
  * 
  * A module for testing the various docstring types.
@@ -32,9 +31,10 @@ fun functionWithoutDocumentation()
  * Lorem ipsum.
  * 
  * Dolor sit amet.
- * 
- * Parameters
- * ----------
+ *
+ * @param no_type_no_default no type and no default
+ * @param type_no_default type but no default
+ * @param with_default foo that defaults to 2
  */
 @Pure
 @PythonName("function_with_parameters")
@@ -50,6 +50,8 @@ fun functionWithParameters(
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @result result_1 return value
  */
 @Pure
 @PythonName("function_with_result_value_and_type")
@@ -90,6 +92,8 @@ class ClassWithoutDocumentation()
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @param p foo defaults to 1
  */
 // TODO Some parameter have no type information.
 class ClassWithParameters(
@@ -129,6 +133,10 @@ class ClassWithMethod() {
 	 * Lorem ipsum.
 	 * 
 	 * Dolor sit amet.
+	 *
+	 * @param a type but no default
+	 *
+	 * @result result_1 return value
 	 */
 	@Pure
 	@PythonName("method_with_docstring")

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[epydoc-EPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[epydoc-EPYDOC].sdsstub
@@ -1,7 +1,21 @@
+/**
+ * 
+ * Test module for docstring tests.
+ * 
+ * A module for testing the various docstring types.
+ */
+
 @PythonModule("tests.data.docstring_parser_package.epydoc")
 package tests.data.docstringParserPackage.epydoc
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum. Code::
+ * 
+ * pass
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_documentation")
 fun functionWithDocumentation()
@@ -14,6 +28,14 @@ fun functionWithoutDocumentation()
 // TODO Result type information missing.
 // TODO Safe-DS does not support variadic parameters.
 // TODO Some parameter have no type information.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ * 
+ * Parameters
+ * ----------
+ */
 @Pure
 @PythonName("function_with_parameters")
 fun functionWithParameters(
@@ -24,35 +46,100 @@ fun functionWithParameters(
 	kwargs: Map<String, Any>
 )
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_result_value_and_type")
 fun functionWithResultValueAndType() -> result1: Boolean
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_result_value_no_type")
 fun functionWithResultValueNoType()
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_without_result_value")
 fun functionWithoutResultValue()
 
+/**
+ * Lorem ipsum. Code::
+ * 
+ * pass
+ * 
+ * Dolor sit amet.
+ */
 class ClassWithDocumentation()
 
 class ClassWithoutDocumentation()
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 // TODO Some parameter have no type information.
 class ClassWithParameters(
 	p
 )
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 class ClassWithAttributes() {
 	static attr p: Int
 	static attr q: Int
 }
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 class ClassWithAttributesNoType() {
 	static attr p: Int
 	static attr q: Int
 }
+
+class ClassWithMethod() {
+	/**
+	 * Lorem ipsum.
+	 * 
+	 * Dolor sit amet.
+	 */
+	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring
+
+	// TODO Some parameter have no type information.
+	/**
+	 * Lorem ipsum.
+	 * 
+	 * Dolor sit amet.
+	 */
+	@Pure
+	@PythonName("method_with_docstring")
+	fun methodWithDocstring(
+		a
+	) -> result1: Boolean
+}
+
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
+enum EnumDocstring

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[epydoc-EPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[epydoc-EPYDOC].sdsstub
@@ -125,8 +125,10 @@ class ClassWithMethod() {
 	 * Lorem ipsum.
 	 * 
 	 * Dolor sit amet.
+	 *
+	 * @result result_1 return value
 	 */
-	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring
+	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring: Boolean
 
 	// TODO Some parameter have no type information.
 	/**

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[full_docstring-PLAINTEXT].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[full_docstring-PLAINTEXT].sdsstub
@@ -1,5 +1,5 @@
 /**
- * Test module for docstring tests.
+ * Test module for full docstring tests.
  * 
  * A module for testing the various docstring types.
  */
@@ -9,7 +9,7 @@ package tests.data.docstringParserPackage.fullDocstring
 
 // TODO Result type information missing.
 /**
- * Lorem ipsum.
+ * function_with_multi_line_documentation.
  * 
  * Dolor sit amet.
  */
@@ -19,7 +19,7 @@ fun functionWithMultiLineDocumentation()
 
 // TODO Result type information missing.
 /**
- * Lorem ipsum.
+ * function_with_single_line_documentation.
  */
 @Pure
 @PythonName("function_with_single_line_documentation")
@@ -31,14 +31,14 @@ fun functionWithSingleLineDocumentation()
 fun functionWithoutDocumentation()
 
 /**
- * Lorem ipsum.
+ * ClassWithMultiLineDocumentation.
  * 
  * Dolor sit amet.
  */
 class ClassWithMultiLineDocumentation()
 
 /**
- * Lorem ipsum.
+ * ClassWithSingleLineDocumentation.
  */
 class ClassWithSingleLineDocumentation()
 

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[full_docstring-PLAINTEXT].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[full_docstring-PLAINTEXT].sdsstub
@@ -1,12 +1,27 @@
+/**
+ * 
+ * Test module for docstring tests.
+ * 
+ * A module for testing the various docstring types.
+ */
+
 @PythonModule("tests.data.docstring_parser_package.full_docstring")
 package tests.data.docstringParserPackage.fullDocstring
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_multi_line_documentation")
 fun functionWithMultiLineDocumentation()
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum.
+ */
 @Pure
 @PythonName("function_with_single_line_documentation")
 fun functionWithSingleLineDocumentation()
@@ -16,8 +31,16 @@ fun functionWithSingleLineDocumentation()
 @PythonName("function_without_documentation")
 fun functionWithoutDocumentation()
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 class ClassWithMultiLineDocumentation()
 
+/**
+ * Lorem ipsum.
+ */
 class ClassWithSingleLineDocumentation()
 
 class ClassWithoutDocumentation()

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[full_docstring-PLAINTEXT].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[full_docstring-PLAINTEXT].sdsstub
@@ -1,0 +1,23 @@
+@PythonModule("tests.data.docstring_parser_package.full_docstring")
+package tests.data.docstringParserPackage.fullDocstring
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_with_multi_line_documentation")
+fun functionWithMultiLineDocumentation()
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_with_single_line_documentation")
+fun functionWithSingleLineDocumentation()
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_without_documentation")
+fun functionWithoutDocumentation()
+
+class ClassWithMultiLineDocumentation()
+
+class ClassWithSingleLineDocumentation()
+
+class ClassWithoutDocumentation()

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[full_docstring-PLAINTEXT].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[full_docstring-PLAINTEXT].sdsstub
@@ -1,5 +1,4 @@
 /**
- * 
  * Test module for docstring tests.
  * 
  * A module for testing the various docstring types.

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
@@ -1,7 +1,20 @@
+/**
+ * Test module for docstring tests.
+ * 
+ * A module for testing the various docstring types.
+ */
+
 @PythonModule("tests.data.docstring_parser_package.googledoc")
 package tests.data.docstringParserPackage.googledoc
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum. Code::
+ * 
+ * pass
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_documentation")
 fun functionWithDocumentation()
@@ -14,6 +27,11 @@ fun functionWithoutDocumentation()
 // TODO Result type information missing.
 // TODO Safe-DS does not support variadic parameters.
 // TODO Some parameter have no type information.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_parameters")
 fun functionWithParameters(
@@ -26,35 +44,72 @@ fun functionWithParameters(
 
 // TODO Result type information missing.
 // TODO Some parameter have no type information.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_attributes_and_parameters")
 fun functionWithAttributesAndParameters(
 	q
 )
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_return_value_and_type")
 fun functionWithReturnValueAndType() -> result1: Boolean
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_return_value_no_type")
 fun functionWithReturnValueNoType()
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_without_return_value")
 fun functionWithoutReturnValue()
 
+/**
+ * Lorem ipsum. Code::
+ * 
+ * pass
+ * 
+ * Dolor sit amet.
+ */
 class ClassWithDocumentation()
 
 class ClassWithoutDocumentation()
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 // TODO Some parameter have no type information.
 class ClassWithParameters(
 	p
 )
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 class ClassWithAttributes() {
 	/**
 	 * foo. Defaults to 1.
@@ -65,3 +120,31 @@ class ClassWithAttributes() {
 	 */
 	static attr q: Int
 }
+
+class ClassWithMethod() {
+	/**
+	 * Lorem ipsum.
+	 * 
+	 * Dolor sit amet.
+	 */
+	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring
+
+	// TODO Some parameter have no type information.
+	/**
+	 * Lorem ipsum.
+	 * 
+	 * Dolor sit amet.
+	 */
+	@Pure
+	@PythonName("method_with_docstring")
+	fun methodWithDocstring(
+		a
+	) -> result1: Boolean
+}
+
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
+enum EnumDocstring

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
@@ -32,9 +32,9 @@ fun functionWithoutDocumentation()
  * 
  * Dolor sit amet.
  *
- * @param no_type_no_default no type and no default.
- * @param type_no_default type but no default.
- * @param with_default foo. Defaults to 2.
+ * @param noTypeNoDefault no type and no default.
+ * @param typeNoDefault type but no default.
+ * @param withDefault foo. Defaults to 2.
  */
 @Pure
 @PythonName("function_with_parameters")
@@ -66,7 +66,7 @@ fun functionWithAttributesAndParameters(
  * 
  * Dolor sit amet.
  *
- * @result result_1 this will be the return value.
+ * @result result1 this will be the return value.
  */
 @Pure
 @PythonName("function_with_return_value_and_type")
@@ -137,7 +137,7 @@ class ClassWithMethod() {
 	 * 
 	 * Dolor sit amet.
 	 *
-	 * @result result_1 this will be the return value.
+	 * @result result1 this will be the return value.
 	 */
 	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring: Boolean
 
@@ -149,7 +149,7 @@ class ClassWithMethod() {
 	 *
 	 * @param a foo
 	 *
-	 * @result result_1 this will be the return value.
+	 * @result result1 this will be the return value.
 	 */
 	@Pure
 	@PythonName("method_with_docstring")

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
@@ -1,0 +1,67 @@
+@PythonModule("tests.data.docstring_parser_package.googledoc")
+package tests.data.docstringParserPackage.googledoc
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_with_documentation")
+fun functionWithDocumentation()
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_without_documentation")
+fun functionWithoutDocumentation()
+
+// TODO Result type information missing.
+// TODO Safe-DS does not support variadic parameters.
+// TODO Some parameter have no type information.
+@Pure
+@PythonName("function_with_parameters")
+fun functionWithParameters(
+	@PythonName("no_type_no_default") noTypeNoDefault,
+	@PythonName("type_no_default") typeNoDefault,
+	@PythonName("with_default") withDefault,
+	args: List<Any>,
+	kwargs: Map<String, Any>
+)
+
+// TODO Result type information missing.
+// TODO Some parameter have no type information.
+@Pure
+@PythonName("function_with_attributes_and_parameters")
+fun functionWithAttributesAndParameters(
+	q
+)
+
+@Pure
+@PythonName("function_with_return_value_and_type")
+fun functionWithReturnValueAndType() -> result1: Boolean
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_with_return_value_no_type")
+fun functionWithReturnValueNoType()
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_without_return_value")
+fun functionWithoutReturnValue()
+
+class ClassWithDocumentation()
+
+class ClassWithoutDocumentation()
+
+// TODO Some parameter have no type information.
+class ClassWithParameters(
+	p
+)
+
+class ClassWithAttributes() {
+	/**
+	 * foo. Defaults to 1.
+	 */
+	static attr p: Int
+	/**
+	 * foo. Defaults to 1.
+	 */
+	static attr q: Int
+}

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
@@ -31,6 +31,10 @@ fun functionWithoutDocumentation()
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @param no_type_no_default no type and no default.
+ * @param type_no_default type but no default.
+ * @param with_default foo. Defaults to 2.
  */
 @Pure
 @PythonName("function_with_parameters")
@@ -48,6 +52,8 @@ fun functionWithParameters(
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @param q foo. Defaults to 2.
  */
 @Pure
 @PythonName("function_with_attributes_and_parameters")
@@ -59,6 +65,8 @@ fun functionWithAttributesAndParameters(
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @result result_1 this will be the return value.
  */
 @Pure
 @PythonName("function_with_return_value_and_type")
@@ -99,6 +107,8 @@ class ClassWithoutDocumentation()
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @param p foo. Defaults to 1.
  */
 // TODO Some parameter have no type information.
 class ClassWithParameters(
@@ -134,6 +144,10 @@ class ClassWithMethod() {
 	 * Lorem ipsum.
 	 * 
 	 * Dolor sit amet.
+	 *
+	 * @param a foo
+	 *
+	 * @result result_1 this will be the return value.
 	 */
 	@Pure
 	@PythonName("method_with_docstring")

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
@@ -136,8 +136,10 @@ class ClassWithMethod() {
 	 * Lorem ipsum.
 	 * 
 	 * Dolor sit amet.
+	 *
+	 * @result result_1 this will be the return value.
 	 */
-	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring
+	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring: Boolean
 
 	// TODO Some parameter have no type information.
 	/**

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
@@ -136,8 +136,6 @@ class ClassWithMethod() {
 	 * Lorem ipsum.
 	 * 
 	 * Dolor sit amet.
-	 *
-	 * @result result1 this will be the return value.
 	 */
 	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring: Boolean
 

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
@@ -1,5 +1,5 @@
 /**
- * Test module for docstring tests.
+ * Test module for Google docstring tests.
  * 
  * A module for testing the various docstring types.
  */
@@ -9,7 +9,7 @@ package tests.data.docstringParserPackage.googledoc
 
 // TODO Result type information missing.
 /**
- * Lorem ipsum. Code::
+ * function_with_documentation. Code::
  * 
  * pass
  * 
@@ -28,7 +28,7 @@ fun functionWithoutDocumentation()
 // TODO Safe-DS does not support variadic parameters.
 // TODO Some parameter have no type information.
 /**
- * Lorem ipsum.
+ * function_with_parameters.
  * 
  * Dolor sit amet.
  *
@@ -49,7 +49,7 @@ fun functionWithParameters(
 // TODO Result type information missing.
 // TODO Some parameter have no type information.
 /**
- * Lorem ipsum.
+ * function_with_attributes_and_parameters.
  * 
  * Dolor sit amet.
  *
@@ -62,7 +62,7 @@ fun functionWithAttributesAndParameters(
 )
 
 /**
- * Lorem ipsum.
+ * function_with_return_value_and_type.
  * 
  * Dolor sit amet.
  *
@@ -74,7 +74,7 @@ fun functionWithReturnValueAndType() -> result1: Boolean
 
 // TODO Result type information missing.
 /**
- * Lorem ipsum.
+ * function_with_return_value_no_type.
  * 
  * Dolor sit amet.
  */
@@ -84,7 +84,7 @@ fun functionWithReturnValueNoType()
 
 // TODO Result type information missing.
 /**
- * Lorem ipsum.
+ * function_without_return_value.
  * 
  * Dolor sit amet.
  */
@@ -93,7 +93,7 @@ fun functionWithReturnValueNoType()
 fun functionWithoutReturnValue()
 
 /**
- * Lorem ipsum. Code::
+ * ClassWithDocumentation. Code::
  * 
  * pass
  * 
@@ -104,7 +104,7 @@ class ClassWithDocumentation()
 class ClassWithoutDocumentation()
 
 /**
- * Lorem ipsum.
+ * ClassWithParameters.
  * 
  * Dolor sit amet.
  *
@@ -116,7 +116,7 @@ class ClassWithParameters(
 )
 
 /**
- * Lorem ipsum.
+ * ClassWithAttributes.
  * 
  * Dolor sit amet.
  */
@@ -133,7 +133,7 @@ class ClassWithAttributes() {
 
 class ClassWithMethod() {
 	/**
-	 * Lorem ipsum.
+	 * property_method_with_docstring.
 	 * 
 	 * Dolor sit amet.
 	 */
@@ -141,7 +141,7 @@ class ClassWithMethod() {
 
 	// TODO Some parameter have no type information.
 	/**
-	 * Lorem ipsum.
+	 * method_with_docstring.
 	 * 
 	 * Dolor sit amet.
 	 *
@@ -157,7 +157,7 @@ class ClassWithMethod() {
 }
 
 /**
- * Lorem ipsum.
+ * EnumDocstring.
  * 
  * Dolor sit amet.
  */

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
@@ -32,16 +32,16 @@ fun functionWithoutDocumentation()
  * 
  * Dolor sit amet.
  *
- * @param no_type_no_default foo: no_type_no_default. Code::
+ * @param noTypeNoDefault foo: no_type_no_default. Code::
  * 
  *     pass
- * @param type_no_default foo: type_no_default
- * @param optional_unknown_default foo: optional_unknown_default
- * @param with_default_syntax_1 foo: with_default_syntax_1
- * @param with_default_syntax_2 foo: with_default_syntax_2
- * @param with_default_syntax_3 foo: with_default_syntax_3
- * @param grouped_parameter_1 foo: grouped_parameter_1 and grouped_parameter_2
- * @param grouped_parameter_2 foo: grouped_parameter_1 and grouped_parameter_2
+ * @param typeNoDefault foo: type_no_default
+ * @param optionalUnknownDefault foo: optional_unknown_default
+ * @param withDefaultSyntax1 foo: with_default_syntax_1
+ * @param withDefaultSyntax2 foo: with_default_syntax_2
+ * @param withDefaultSyntax3 foo: with_default_syntax_3
+ * @param groupedParameter1 foo: grouped_parameter_1 and grouped_parameter_2
+ * @param groupedParameter2 foo: grouped_parameter_1 and grouped_parameter_2
  * @param args foo: *args
  * @param kwargs foo: **kwargs
  */
@@ -65,7 +65,7 @@ fun functionWithParameters(
  * 
  * Dolor sit amet.
  *
- * @result result_1 this will be the return value
+ * @result result1 this will be the return value
  */
 @Pure
 @PythonName("function_with_result_value_and_type")
@@ -76,7 +76,7 @@ fun functionWithResultValueAndType() -> result1: Boolean
  * 
  * Dolor sit amet.
  *
- * @result result_1 this will be the return value
+ * @result result1 this will be the return value
  */
 @Pure
 @PythonName("function_with_named_result")
@@ -204,7 +204,7 @@ class ClassWithMethod() {
 	 * 
 	 * Dolor sit amet.
 	 *
-	 * @result result_1 this will be the return value
+	 * @result result1 this will be the return value
 	 */
 	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring: Boolean
 
@@ -214,7 +214,7 @@ class ClassWithMethod() {
 	 * 
 	 * Dolor sit amet.
 	 *
-	 * @result result_1 this will be the return value
+	 * @result result1 this will be the return value
 	 */
 	@Pure
 	@PythonName("method_with_docstring")

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
@@ -203,8 +203,10 @@ class ClassWithMethod() {
 	 * Lorem ipsum.
 	 * 
 	 * Dolor sit amet.
+	 *
+	 * @result result_1 this will be the return value
 	 */
-	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring
+	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring: Boolean
 
 	// TODO Some parameter have no type information.
 	/**

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
@@ -203,8 +203,6 @@ class ClassWithMethod() {
 	 * Lorem ipsum.
 	 * 
 	 * Dolor sit amet.
-	 *
-	 * @result result1 this will be the return value
 	 */
 	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring: Boolean
 

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
@@ -1,7 +1,21 @@
+/**
+ * 
+ * Test module for docstring tests.
+ * 
+ * A module for testing the various docstring types.
+ */
+
 @PythonModule("tests.data.docstring_parser_package.numpydoc")
 package tests.data.docstringParserPackage.numpydoc
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum. Code::
+ * 
+ * pass
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_documentation")
 fun functionWithDocumentation()
@@ -14,6 +28,11 @@ fun functionWithoutDocumentation()
 // TODO Result type information missing.
 // TODO Safe-DS does not support variadic parameters.
 // TODO Some parameter have no type information.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_parameters")
 fun functionWithParameters(
@@ -29,23 +48,50 @@ fun functionWithParameters(
 	kwargs: Map<String, Any>
 )
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_result_value_and_type")
 fun functionWithResultValueAndType() -> result1: Boolean
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_named_result")
 fun functionWithNamedResult() -> result1: Boolean
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_without_result_value")
 fun functionWithoutResultValue()
 
+/**
+ * Lorem ipsum. Code::
+ * 
+ * pass
+ * 
+ * Dolor sit amet.
+ */
 class ClassWithDocumentation()
 
 class ClassWithoutDocumentation()
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 // TODO Some parameter have no type information.
 class ClassWithParameters(
 	p
@@ -58,6 +104,11 @@ class ClassAndConstructorWithParameters(
 	z
 )
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 // TODO Some parameter have no type information.
 class ClassWithParametersAndAttributes(
 	x
@@ -72,11 +123,16 @@ class ClassWithParametersAndAttributes(
 	static attr q: Int
 }
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 class ClassWithAttributes() {
 	/**
 	 * foo: no_type_no_default. Code::
-
-    pass
+	 * 
+	 *     pass
 	 */
 	@PythonName("no_type_no_default")
 	static attr noTypeNoDefault: Any
@@ -116,3 +172,31 @@ class ClassWithAttributes() {
 	@PythonName("grouped_attribute_2")
 	static attr groupedAttribute2: Int
 }
+
+class ClassWithMethod() {
+	/**
+	 * Lorem ipsum.
+	 * 
+	 * Dolor sit amet.
+	 */
+	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring
+
+	// TODO Some parameter have no type information.
+	/**
+	 * Lorem ipsum.
+	 * 
+	 * Dolor sit amet.
+	 */
+	@Pure
+	@PythonName("method_with_docstring")
+	fun methodWithDocstring(
+		a
+	) -> result1: Boolean
+}
+
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
+enum EnumDocstring

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
@@ -1,5 +1,4 @@
 /**
- * 
  * Test module for docstring tests.
  * 
  * A module for testing the various docstring types.
@@ -32,6 +31,19 @@ fun functionWithoutDocumentation()
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @param no_type_no_default foo: no_type_no_default. Code::
+ * 
+ *     pass
+ * @param type_no_default foo: type_no_default
+ * @param optional_unknown_default foo: optional_unknown_default
+ * @param with_default_syntax_1 foo: with_default_syntax_1
+ * @param with_default_syntax_2 foo: with_default_syntax_2
+ * @param with_default_syntax_3 foo: with_default_syntax_3
+ * @param grouped_parameter_1 foo: grouped_parameter_1 and grouped_parameter_2
+ * @param grouped_parameter_2 foo: grouped_parameter_1 and grouped_parameter_2
+ * @param args foo: *args
+ * @param kwargs foo: **kwargs
  */
 @Pure
 @PythonName("function_with_parameters")
@@ -52,6 +64,8 @@ fun functionWithParameters(
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @result result_1 this will be the return value
  */
 @Pure
 @PythonName("function_with_result_value_and_type")
@@ -61,6 +75,8 @@ fun functionWithResultValueAndType() -> result1: Boolean
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @result result_1 this will be the return value
  */
 @Pure
 @PythonName("function_with_named_result")
@@ -91,12 +107,19 @@ class ClassWithoutDocumentation()
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @param p foo
  */
 // TODO Some parameter have no type information.
 class ClassWithParameters(
 	p
 )
 
+/**
+ * @param x Lorem ipsum 1.
+ * @param y Lorem ipsum 2.
+ * @param z Lorem ipsum 3.
+ */
 // TODO Some parameter have no type information.
 class ClassAndConstructorWithParameters(
 	x,
@@ -108,6 +131,8 @@ class ClassAndConstructorWithParameters(
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @param x foo
  */
 // TODO Some parameter have no type information.
 class ClassWithParametersAndAttributes(
@@ -186,6 +211,8 @@ class ClassWithMethod() {
 	 * Lorem ipsum.
 	 * 
 	 * Dolor sit amet.
+	 *
+	 * @result result_1 this will be the return value
 	 */
 	@Pure
 	@PythonName("method_with_docstring")

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
@@ -1,5 +1,5 @@
 /**
- * Test module for docstring tests.
+ * Test module for Numpy docstring tests.
  * 
  * A module for testing the various docstring types.
  */
@@ -9,7 +9,7 @@ package tests.data.docstringParserPackage.numpydoc
 
 // TODO Result type information missing.
 /**
- * Lorem ipsum. Code::
+ * function_with_documentation. Code::
  * 
  * pass
  * 
@@ -28,7 +28,7 @@ fun functionWithoutDocumentation()
 // TODO Safe-DS does not support variadic parameters.
 // TODO Some parameter have no type information.
 /**
- * Lorem ipsum.
+ * function_with_parameters.
  * 
  * Dolor sit amet.
  *
@@ -61,7 +61,7 @@ fun functionWithParameters(
 )
 
 /**
- * Lorem ipsum.
+ * function_with_result_value_and_type.
  * 
  * Dolor sit amet.
  *
@@ -72,7 +72,7 @@ fun functionWithParameters(
 fun functionWithResultValueAndType() -> result1: Boolean
 
 /**
- * Lorem ipsum.
+ * function_with_named_result.
  * 
  * Dolor sit amet.
  *
@@ -84,7 +84,7 @@ fun functionWithNamedResult() -> result1: Boolean
 
 // TODO Result type information missing.
 /**
- * Lorem ipsum.
+ * function_without_result_value.
  * 
  * Dolor sit amet.
  */
@@ -93,7 +93,7 @@ fun functionWithNamedResult() -> result1: Boolean
 fun functionWithoutResultValue()
 
 /**
- * Lorem ipsum. Code::
+ * ClassWithDocumentation. Code::
  * 
  * pass
  * 
@@ -104,7 +104,7 @@ class ClassWithDocumentation()
 class ClassWithoutDocumentation()
 
 /**
- * Lorem ipsum.
+ * ClassWithParameters.
  * 
  * Dolor sit amet.
  *
@@ -116,6 +116,10 @@ class ClassWithParameters(
 )
 
 /**
+ * ClassAndConstructorWithParameters
+ * 
+ * Dolor sit amet.
+ *
  * @param x Lorem ipsum 1.
  * @param y Lorem ipsum 2.
  * @param z Lorem ipsum 3.
@@ -128,7 +132,7 @@ class ClassAndConstructorWithParameters(
 )
 
 /**
- * Lorem ipsum.
+ * ClassWithParametersAndAttributes.
  * 
  * Dolor sit amet.
  *
@@ -149,7 +153,7 @@ class ClassWithParametersAndAttributes(
 }
 
 /**
- * Lorem ipsum.
+ * ClassWithAttributes.
  * 
  * Dolor sit amet.
  */
@@ -200,7 +204,7 @@ class ClassWithAttributes() {
 
 class ClassWithMethod() {
 	/**
-	 * Lorem ipsum.
+	 * property_method_with_docstring.
 	 * 
 	 * Dolor sit amet.
 	 */
@@ -208,7 +212,7 @@ class ClassWithMethod() {
 
 	// TODO Some parameter have no type information.
 	/**
-	 * Lorem ipsum.
+	 * method_with_docstring.
 	 * 
 	 * Dolor sit amet.
 	 *
@@ -222,7 +226,7 @@ class ClassWithMethod() {
 }
 
 /**
- * Lorem ipsum.
+ * EnumDocstring.
  * 
  * Dolor sit amet.
  */

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
@@ -1,0 +1,118 @@
+@PythonModule("tests.data.docstring_parser_package.numpydoc")
+package tests.data.docstringParserPackage.numpydoc
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_with_documentation")
+fun functionWithDocumentation()
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_without_documentation")
+fun functionWithoutDocumentation()
+
+// TODO Result type information missing.
+// TODO Safe-DS does not support variadic parameters.
+// TODO Some parameter have no type information.
+@Pure
+@PythonName("function_with_parameters")
+fun functionWithParameters(
+	@PythonName("no_type_no_default") noTypeNoDefault,
+	@PythonName("type_no_default") typeNoDefault,
+	@PythonName("optional_unknown_default") optionalUnknownDefault,
+	@PythonName("with_default_syntax_1") withDefaultSyntax1,
+	@PythonName("with_default_syntax_2") withDefaultSyntax2,
+	@PythonName("with_default_syntax_3") withDefaultSyntax3,
+	@PythonName("grouped_parameter_1") groupedParameter1,
+	@PythonName("grouped_parameter_2") groupedParameter2,
+	args: List<Any>,
+	kwargs: Map<String, Any>
+)
+
+@Pure
+@PythonName("function_with_result_value_and_type")
+fun functionWithResultValueAndType() -> result1: Boolean
+
+@Pure
+@PythonName("function_with_named_result")
+fun functionWithNamedResult() -> result1: Boolean
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_without_result_value")
+fun functionWithoutResultValue()
+
+class ClassWithDocumentation()
+
+class ClassWithoutDocumentation()
+
+// TODO Some parameter have no type information.
+class ClassWithParameters(
+	p
+)
+
+// TODO Some parameter have no type information.
+class ClassAndConstructorWithParameters(
+	x,
+	y,
+	z
+)
+
+// TODO Some parameter have no type information.
+class ClassWithParametersAndAttributes(
+	x
+) {
+	/**
+	 * foo
+	 */
+	static attr p: Int
+	/**
+	 * foo
+	 */
+	static attr q: Int
+}
+
+class ClassWithAttributes() {
+	/**
+	 * foo: no_type_no_default. Code::
+
+    pass
+	 */
+	@PythonName("no_type_no_default")
+	static attr noTypeNoDefault: Any
+	/**
+	 * foo: type_no_default
+	 */
+	@PythonName("type_no_default")
+	static attr typeNoDefault: Int
+	/**
+	 * foo: optional_unknown_default
+	 */
+	@PythonName("optional_unknown_default")
+	static attr optionalUnknownDefault: Int?
+	/**
+	 * foo: with_default_syntax_1
+	 */
+	@PythonName("with_default_syntax_1")
+	static attr withDefaultSyntax1: Int
+	/**
+	 * foo: with_default_syntax_2
+	 */
+	@PythonName("with_default_syntax_2")
+	static attr withDefaultSyntax2: Int
+	/**
+	 * foo: with_default_syntax_3
+	 */
+	@PythonName("with_default_syntax_3")
+	static attr withDefaultSyntax3: Int
+	/**
+	 * foo: grouped_attribute_1 and grouped_attribute_2
+	 */
+	@PythonName("grouped_attribute_1")
+	static attr groupedAttribute1: Int
+	/**
+	 * foo: grouped_attribute_1 and grouped_attribute_2
+	 */
+	@PythonName("grouped_attribute_2")
+	static attr groupedAttribute2: Int
+}

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[plaintext-PLAINTEXT].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[plaintext-PLAINTEXT].sdsstub
@@ -1,5 +1,5 @@
 /**
- * Test module for docstring tests.
+ * Test module for plaintext docstring tests.
  * 
  * A module for testing the various docstring types.
  */
@@ -9,7 +9,7 @@ package tests.data.docstringParserPackage.plaintext
 
 // TODO Result type information missing.
 /**
- * Lorem ipsum.
+ * function_with_documentation.
  * 
  * Dolor sit amet.
  */
@@ -27,7 +27,7 @@ fun functionWithoutDocumentation(
 )
 
 /**
- * Lorem ipsum.
+ * ClassWithDocumentation.
  * 
  * Dolor sit amet.
  */

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[plaintext-PLAINTEXT].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[plaintext-PLAINTEXT].sdsstub
@@ -1,7 +1,18 @@
+/**
+ * Test module for docstring tests.
+ * 
+ * A module for testing the various docstring types.
+ */
+
 @PythonModule("tests.data.docstring_parser_package.plaintext")
 package tests.data.docstringParserPackage.plaintext
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_documentation")
 fun functionWithDocumentation(
@@ -15,6 +26,11 @@ fun functionWithoutDocumentation(
 	p: Int
 )
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 class ClassWithDocumentation(
 	p: Int
 )

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[plaintext-PLAINTEXT].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[plaintext-PLAINTEXT].sdsstub
@@ -1,0 +1,22 @@
+@PythonModule("tests.data.docstring_parser_package.plaintext")
+package tests.data.docstringParserPackage.plaintext
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_with_documentation")
+fun functionWithDocumentation(
+	p: Int
+)
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_without_documentation")
+fun functionWithoutDocumentation(
+	p: Int
+)
+
+class ClassWithDocumentation(
+	p: Int
+)
+
+class ClassWithoutDocumentation()

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
@@ -105,8 +105,6 @@ class ClassWithMethod() {
 	 * Lorem ipsum.
 	 * 
 	 * Dolor sit amet.
-	 *
-	 * @result result1 return value
 	 */
 	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring: Boolean
 

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
@@ -1,5 +1,4 @@
 /**
- * 
  * Test module for docstring tests.
  * 
  * A module for testing the various docstring types.
@@ -32,6 +31,10 @@ fun functionWithoutDocumentation()
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @param no_type_no_default no type and no default
+ * @param type_no_default type but no default
+ * @param with_default foo that defaults to 2
  */
 @Pure
 @PythonName("function_with_parameters")
@@ -47,6 +50,8 @@ fun functionWithParameters(
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @result result_1 return value
  */
 @Pure
 @PythonName("function_with_return_value_and_type")
@@ -87,6 +92,8 @@ class ClassWithoutDocumentation()
  * Lorem ipsum.
  * 
  * Dolor sit amet.
+ *
+ * @param p foo defaults to 1
  */
 // TODO Some parameter have no type information.
 class ClassWithParameters(
@@ -106,6 +113,10 @@ class ClassWithMethod() {
 	 * Lorem ipsum.
 	 * 
 	 * Dolor sit amet.
+	 *
+	 * @param a type but no default
+	 *
+	 * @result result_1 return value
 	 */
 	@Pure
 	@PythonName("method_with_docstring")

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
@@ -1,7 +1,21 @@
+/**
+ * 
+ * Test module for docstring tests.
+ * 
+ * A module for testing the various docstring types.
+ */
+
 @PythonModule("tests.data.docstring_parser_package.restdoc")
 package tests.data.docstringParserPackage.restdoc
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum. Code::
+ * 
+ * pass
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_documentation")
 fun functionWithDocumentation()
@@ -14,6 +28,11 @@ fun functionWithoutDocumentation()
 // TODO Result type information missing.
 // TODO Safe-DS does not support variadic parameters.
 // TODO Some parameter have no type information.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_parameters")
 fun functionWithParameters(
@@ -24,25 +43,80 @@ fun functionWithParameters(
 	kwargs: Map<String, Any>
 )
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_return_value_and_type")
 fun functionWithReturnValueAndType() -> result1: Boolean
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_with_return_value_no_type")
 fun functionWithReturnValueNoType()
 
 // TODO Result type information missing.
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 @Pure
 @PythonName("function_without_return_value")
 fun functionWithoutReturnValue()
 
+/**
+ * Lorem ipsum. Code::
+ * 
+ * pass
+ * 
+ * Dolor sit amet.
+ */
 class ClassWithDocumentation()
 
 class ClassWithoutDocumentation()
 
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
 // TODO Some parameter have no type information.
 class ClassWithParameters(
 	p
 )
+
+class ClassWithMethod() {
+	/**
+	 * Lorem ipsum.
+	 * 
+	 * Dolor sit amet.
+	 */
+	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring
+
+	// TODO Some parameter have no type information.
+	/**
+	 * Lorem ipsum.
+	 * 
+	 * Dolor sit amet.
+	 */
+	@Pure
+	@PythonName("method_with_docstring")
+	fun methodWithDocstring(
+		a
+	) -> result1: Boolean
+}
+
+/**
+ * Lorem ipsum.
+ * 
+ * Dolor sit amet.
+ */
+enum EnumDocstring

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
@@ -1,0 +1,48 @@
+@PythonModule("tests.data.docstring_parser_package.restdoc")
+package tests.data.docstringParserPackage.restdoc
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_with_documentation")
+fun functionWithDocumentation()
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_without_documentation")
+fun functionWithoutDocumentation()
+
+// TODO Result type information missing.
+// TODO Safe-DS does not support variadic parameters.
+// TODO Some parameter have no type information.
+@Pure
+@PythonName("function_with_parameters")
+fun functionWithParameters(
+	@PythonName("no_type_no_default") noTypeNoDefault,
+	@PythonName("type_no_default") typeNoDefault,
+	@PythonName("with_default") withDefault,
+	args: List<Any>,
+	kwargs: Map<String, Any>
+)
+
+@Pure
+@PythonName("function_with_return_value_and_type")
+fun functionWithReturnValueAndType() -> result1: Boolean
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_with_return_value_no_type")
+fun functionWithReturnValueNoType()
+
+// TODO Result type information missing.
+@Pure
+@PythonName("function_without_return_value")
+fun functionWithoutReturnValue()
+
+class ClassWithDocumentation()
+
+class ClassWithoutDocumentation()
+
+// TODO Some parameter have no type information.
+class ClassWithParameters(
+	p
+)

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
@@ -32,9 +32,9 @@ fun functionWithoutDocumentation()
  * 
  * Dolor sit amet.
  *
- * @param no_type_no_default no type and no default
- * @param type_no_default type but no default
- * @param with_default foo that defaults to 2
+ * @param noTypeNoDefault no type and no default
+ * @param typeNoDefault type but no default
+ * @param withDefault foo that defaults to 2
  */
 @Pure
 @PythonName("function_with_parameters")
@@ -51,7 +51,7 @@ fun functionWithParameters(
  * 
  * Dolor sit amet.
  *
- * @result result_1 return value
+ * @result result1 return value
  */
 @Pure
 @PythonName("function_with_return_value_and_type")
@@ -106,7 +106,7 @@ class ClassWithMethod() {
 	 * 
 	 * Dolor sit amet.
 	 *
-	 * @result result_1 return value
+	 * @result result1 return value
 	 */
 	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring: Boolean
 
@@ -118,7 +118,7 @@ class ClassWithMethod() {
 	 *
 	 * @param a type but no default
 	 *
-	 * @result result_1 return value
+	 * @result result1 return value
 	 */
 	@Pure
 	@PythonName("method_with_docstring")

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
@@ -1,5 +1,5 @@
 /**
- * Test module for docstring tests.
+ * Test module for ReST docstring tests.
  * 
  * A module for testing the various docstring types.
  */
@@ -9,7 +9,7 @@ package tests.data.docstringParserPackage.restdoc
 
 // TODO Result type information missing.
 /**
- * Lorem ipsum. Code::
+ * function_with_documentation. Code::
  * 
  * pass
  * 
@@ -28,7 +28,7 @@ fun functionWithoutDocumentation()
 // TODO Safe-DS does not support variadic parameters.
 // TODO Some parameter have no type information.
 /**
- * Lorem ipsum.
+ * function_with_parameters.
  * 
  * Dolor sit amet.
  *
@@ -47,7 +47,7 @@ fun functionWithParameters(
 )
 
 /**
- * Lorem ipsum.
+ * function_with_return_value_and_type.
  * 
  * Dolor sit amet.
  *
@@ -59,7 +59,7 @@ fun functionWithReturnValueAndType() -> result1: Boolean
 
 // TODO Result type information missing.
 /**
- * Lorem ipsum.
+ * function_with_return_value_no_type.
  * 
  * Dolor sit amet.
  */
@@ -69,7 +69,7 @@ fun functionWithReturnValueNoType()
 
 // TODO Result type information missing.
 /**
- * Lorem ipsum.
+ * function_without_return_value.
  * 
  * Dolor sit amet.
  */
@@ -78,7 +78,7 @@ fun functionWithReturnValueNoType()
 fun functionWithoutReturnValue()
 
 /**
- * Lorem ipsum. Code::
+ * ClassWithDocumentation. Code::
  * 
  * pass
  * 
@@ -89,7 +89,7 @@ class ClassWithDocumentation()
 class ClassWithoutDocumentation()
 
 /**
- * Lorem ipsum.
+ * ClassWithParameters.
  * 
  * Dolor sit amet.
  *
@@ -102,7 +102,7 @@ class ClassWithParameters(
 
 class ClassWithMethod() {
 	/**
-	 * Lorem ipsum.
+	 * property_method_with_docstring.
 	 * 
 	 * Dolor sit amet.
 	 */
@@ -110,7 +110,7 @@ class ClassWithMethod() {
 
 	// TODO Some parameter have no type information.
 	/**
-	 * Lorem ipsum.
+	 * method_with_docstring.
 	 * 
 	 * Dolor sit amet.
 	 *
@@ -126,7 +126,7 @@ class ClassWithMethod() {
 }
 
 /**
- * Lorem ipsum.
+ * EnumDocstring.
  * 
  * Dolor sit amet.
  */

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
@@ -105,8 +105,10 @@ class ClassWithMethod() {
 	 * Lorem ipsum.
 	 * 
 	 * Dolor sit amet.
+	 *
+	 * @result result_1 return value
 	 */
-	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring
+	@PythonName("property_method_with_docstring") attr propertyMethodWithDocstring: Boolean
 
 	// TODO Some parameter have no type information.
 	/**

--- a/tests/safeds_stubgen/stubs_generator/test_generate_stubs.py
+++ b/tests/safeds_stubgen/stubs_generator/test_generate_stubs.py
@@ -152,8 +152,12 @@ def test_convert_name_to_convention(
         ("restdoc", DocstringStyle.REST),
     ]
 )
-def test_stub_docstring_creation(filename: str, docstring_style: DocstringStyle, snapshot_sds_stub: SnapshotAssertion):
-    docstring_api = get_api(_docstring_package_name, _docstring_package_dir, docstring_style=docstring_style, is_test_run=True)
+def test_stub_docstring_creation(
+    filename: str, docstring_style: DocstringStyle, snapshot_sds_stub: SnapshotAssertion
+) -> None:
+    docstring_api = get_api(
+        _docstring_package_name, _docstring_package_dir, docstring_style=docstring_style, is_test_run=True
+    )
     docstring_stubs_generator = StubsStringGenerator(docstring_api, naming_convention=NamingConvention.SAFE_DS)
     docstring_stubs_data = _generate_stubs_data(docstring_api, _out_dir, docstring_stubs_generator)
 

--- a/tests/safeds_stubgen/stubs_generator/test_generate_stubs.py
+++ b/tests/safeds_stubgen/stubs_generator/test_generate_stubs.py
@@ -108,7 +108,7 @@ class TestStubFileGeneration:
         if file_name in {"__init__", "_module_2", "_module_4", "_reexport_module_5"}:
             return
 
-        raise AssertionError(f"Stub file not found for '{file_name}'.")
+        raise pytest.fail(f"Stub file not found for '{file_name}'.")
 
 
 @pytest.mark.parametrize(
@@ -171,4 +171,4 @@ def test_stub_docstring_creation(
             assert stub_text[2] == snapshot_sds_stub
             return
 
-    raise AssertionError
+    raise pytest.fail(f"Could not find data for '{filename}'.")


### PR DESCRIPTION
### Summary of Changes
Added docstring information support for all docstring types, excluding attribute information for Epydoc docstrings.

The following is included:
- [X] Module docstring
- [X] Class parameter docstrings
- [X] Class attribute docstrings
- [x] docstrings for ```@property``` methods
- [X] Function parameter docstrings
- [X] Function result docstrings
