### PR TITLE
fix: Generated names of callback results start with result, not with param

### DIFF
--- a/src/safeds_stubgen/stubs_generator/_generate_stubs.py
+++ b/src/safeds_stubgen/stubs_generator/_generate_stubs.py
@@ -701,21 +701,23 @@ class StubsStringGenerator:
         elif kind == "FinalType":
             return self._create_type_string(type_data["type"])
         elif kind == "CallableType":
-            name_generator = _callable_type_name_generator()
-
             params = [
-                f"{next(name_generator)}: {self._create_type_string(parameter_type)}"
-                for parameter_type in type_data["parameter_types"]
+                (f"{_convert_name_to_convention('param_' + str(i + 1), self.naming_convention)}: "
+                 f"{self._create_type_string(parameter_type)}")
+                for i, parameter_type in enumerate(type_data["parameter_types"])
             ]
 
             return_type = type_data["return_type"]
             if return_type["kind"] == "TupleType":
                 return_types = [
-                    f"{next(name_generator)}: {self._create_type_string(type_)}" for type_ in return_type["types"]
+                    (f"{_convert_name_to_convention('result_' + str(i+1), self.naming_convention)}: "
+                     f"{self._create_type_string(type_)}")
+                    for i, type_ in enumerate(return_type["types"])
                 ]
                 return_type_string = f"({', '.join(return_types)})"
             else:
-                return_type_string = f"{next(name_generator)}: {self._create_type_string(return_type)}"
+                result_name = _convert_name_to_convention("result_1", self.naming_convention)
+                return_type_string = f"{result_name}: {self._create_type_string(return_type)}"
 
             return f"({', '.join(params)}) -> {return_type_string}"
         elif kind in {"SetType", "ListType"}:
@@ -1033,13 +1035,6 @@ class StubsStringGenerator:
                 full_docstring += f"\n{indentations} *"
 
         return full_docstring + "\n"
-
-
-def _callable_type_name_generator() -> Generator:
-    """Generate a name for callable type parameters starting from 'a' until 'zz'."""
-    while True:
-        for x in range(1, 1000):
-            yield f"param{x}"
 
 
 def _create_name_annotation(name: str) -> str:

--- a/src/safeds_stubgen/stubs_generator/_generate_stubs.py
+++ b/src/safeds_stubgen/stubs_generator/_generate_stubs.py
@@ -19,7 +19,6 @@ from safeds_stubgen.api_analyzer import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
 
     from safeds_stubgen.docstring_parsing import AttributeDocstring, ClassDocstring, FunctionDocstring
 
@@ -702,16 +701,20 @@ class StubsStringGenerator:
             return self._create_type_string(type_data["type"])
         elif kind == "CallableType":
             params = [
-                (f"{_convert_name_to_convention('param_' + str(i + 1), self.naming_convention)}: "
-                 f"{self._create_type_string(parameter_type)}")
+                (
+                    f"{_convert_name_to_convention('param_' + str(i + 1), self.naming_convention)}: "
+                    f"{self._create_type_string(parameter_type)}"
+                )
                 for i, parameter_type in enumerate(type_data["parameter_types"])
             ]
 
             return_type = type_data["return_type"]
             if return_type["kind"] == "TupleType":
                 return_types = [
-                    (f"{_convert_name_to_convention('result_' + str(i+1), self.naming_convention)}: "
-                     f"{self._create_type_string(type_)}")
+                    (
+                        f"{_convert_name_to_convention('result_' + str(i+1), self.naming_convention)}: "
+                        f"{self._create_type_string(type_)}"
+                    )
                     for i, type_ in enumerate(return_type["types"])
                 ]
                 return_type_string = f"({', '.join(return_types)})"

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[function_module].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[function_module].sdsstub
@@ -233,8 +233,8 @@ fun anyResults() -> result1: Any
 @Pure
 @PythonName("callable_type")
 fun callableType(
-	param: (param1: String) -> (param2: Int, param3: String)
-) -> result1: (param1: Int, param2: Int) -> param3: Int
+	param: (param1: String) -> (result1: Int, result2: String)
+) -> result1: (param1: Int, param2: Int) -> result1: Int
 
 // TODO Result type information missing.
 // TODO Some parameter have no type information.


### PR DESCRIPTION
Closes #85

### Summary of Changes

Fixed the bug where generated names of callback results started with `param` instead of `result`.