### PR TITLE
fix: `Self` types as results are translated to class names 

### DIFF
--- a/src/safeds_stubgen/api_analyzer/_ast_visitor.py
+++ b/src/safeds_stubgen/api_analyzer/_ast_visitor.py
@@ -500,6 +500,10 @@ class MyPyAstVisitor:
                                 type_ = mypy_expression_to_sds_type(conditional_branch)
                                 if isinstance(type_, sds_types.NamedType | sds_types.TupleType):
                                     types.add(type_)
+                    elif hasattr(return_stmt.expr, "node") and getattr(return_stmt.expr.node, "is_self", False):
+                        # The result type is an instance of the parent class
+                        expr_type = return_stmt.expr.node.type.type
+                        types.add(sds_types.NamedType(name=expr_type.name, qname=expr_type.fullname))
                     else:
                         type_ = mypy_expression_to_sds_type(return_stmt.expr)
                         if isinstance(type_, sds_types.NamedType | sds_types.TupleType):
@@ -913,6 +917,10 @@ class MyPyAstVisitor:
             type_ = None
             if upper_bound.__str__() != "builtins.object":
                 type_ = self.mypy_type_to_abstract_type(upper_bound)
+
+                if mypy_type.name == "Self":
+                    # Special case, where the method returns an instance of its class
+                    return type_
 
             type_var = sds_types.TypeVarType(name=mypy_type.name, upper_bound=type_)
             self.type_var_types.add(type_var)

--- a/tests/data/various_modules_package/class_module.py
+++ b/tests/data/various_modules_package/class_module.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 from tests.data.main_package.another_path.another_module import yetAnotherClass
 
 
@@ -41,3 +43,16 @@ class InheritFromException(ValueError):
 
 class InheritFromException2(Exception, InheritFromException, ClassModuleClassB):
     ...
+
+
+class SelfTypes1:
+    def self_result1(self) -> Self:
+        pass
+
+
+class SelfTypes2(SelfTypes1):
+    def self_result2(self) -> Self:
+        pass
+
+    def infer_self_result2(self):
+        return self

--- a/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
+++ b/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
@@ -6679,6 +6679,8 @@
       'tests/data/various_modules_package/class_module/_ClassModulePrivateClassG',
       'tests/data/various_modules_package/class_module/InheritFromException',
       'tests/data/various_modules_package/class_module/InheritFromException2',
+      'tests/data/various_modules_package/class_module/SelfTypes1',
+      'tests/data/various_modules_package/class_module/SelfTypes2',
     ]),
     'docstring': '',
     'enums': list([
@@ -6688,6 +6690,10 @@
     'id': 'tests/data/various_modules_package/class_module',
     'name': 'class_module',
     'qualified_imports': list([
+      dict({
+        'alias': None,
+        'qualified_name': 'typing.Self',
+      }),
       dict({
         'alias': None,
         'qualified_name': 'tests.data.main_package.another_path.another_module.yetAnotherClass',

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[class_module].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[class_module].sdsstub
@@ -40,3 +40,19 @@ class ClassModuleClassD() {
         fun classEFunc()
     }
 }
+
+class SelfTypes1() {
+    @Pure
+    @PythonName("self_result1")
+    fun selfResult1() -> result1: SelfTypes1
+}
+
+class SelfTypes2() sub SelfTypes1 {
+    @Pure
+    @PythonName("self_result2")
+    fun selfResult2() -> result1: SelfTypes2
+
+    @Pure
+    @PythonName("infer_self_result2")
+    fun inferSelfResult2() -> result1: SelfTypes2
+}


### PR DESCRIPTION
Closes #86

### Summary of Changes
`Self`s as result types are now translated to the corresponding class names.