### PR TITLE
fix: No "// TODO ..." if return type is explicitly `None`

### DIFF
--- a/src/safeds_stubgen/api_analyzer/_ast_visitor.py
+++ b/src/safeds_stubgen/api_analyzer/_ast_visitor.py
@@ -423,7 +423,9 @@ class MyPyAstVisitor:
             if node_type is not None and hasattr(node_type, "ret_type"):
                 node_ret_type = node_type.ret_type
 
-                if not isinstance(node_ret_type, mp_types.NoneType):
+                if isinstance(node_ret_type, mp_types.NoneType):
+                    ret_type = sds_types.NamedType(name="None", qname="builtins.None")
+                else:
                     unanalyzed_ret_type = getattr(node.unanalyzed_type, "ret_type", None)
 
                     if (

--- a/src/safeds_stubgen/stubs_generator/_generate_stubs.py
+++ b/src/safeds_stubgen/stubs_generator/_generate_stubs.py
@@ -542,6 +542,10 @@ class StubsStringGenerator:
                 continue
 
             result_type = result.type.to_dict()
+
+            if result_type["kind"] == "NamedType" and result_type["qname"] == "builtins.None":
+                return ""
+
             ret_type = self._create_type_string(result_type)
             type_string = f": {ret_type}" if ret_type else ""
             result_name = _convert_name_to_convention(result.name, self.naming_convention)

--- a/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
+++ b/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
@@ -1424,6 +1424,7 @@
       'reexported_by': list([
       ]),
       'results': list([
+        'tests/data/various_modules_package/function_module/FunctionModuleClassB/static_method_params/result_1',
       ]),
     }),
   ])
@@ -1808,6 +1809,7 @@
         'tests/data/various_modules_package',
       ]),
       'results': list([
+        'tests/data/various_modules_package/_reexport_module_1/ReexportClass/_private_class_method_of_reexported_class/result_1',
       ]),
     }),
   ])
@@ -5021,6 +5023,15 @@
 # ---
 # name: test_function_results[none_result]
   list([
+    dict({
+      'id': 'tests/data/various_modules_package/function_module/none_result/result_1',
+      'name': 'result_1',
+      'type': dict({
+        'kind': 'NamedType',
+        'name': 'None',
+        'qname': 'builtins.None',
+      }),
+    }),
   ])
 # ---
 # name: test_function_results[numpy_docstring_func]
@@ -5148,6 +5159,15 @@
 # ---
 # name: test_function_results[static_method_params]
   list([
+    dict({
+      'id': 'tests/data/various_modules_package/function_module/FunctionModuleClassB/static_method_params/result_1',
+      'name': 'result_1',
+      'type': dict({
+        'kind': 'NamedType',
+        'name': 'None',
+        'qname': 'builtins.None',
+      }),
+    }),
   ])
 # ---
 # name: test_function_results[str_result]
@@ -5286,6 +5306,7 @@
         'tests/data/various_modules_package',
       ]),
       'results': list([
+        'tests/data/various_modules_package/_reexport_module_1/reexported_function/result_1',
       ]),
     }),
   ])
@@ -5309,6 +5330,7 @@
         'tests/data/various_modules_package',
       ]),
       'results': list([
+        'tests/data/various_modules_package/_reexport_module_2/reexported_function_2/result_1',
       ]),
     }),
   ])
@@ -5332,6 +5354,7 @@
         'tests/data/various_modules_package',
       ]),
       'results': list([
+        'tests/data/various_modules_package/_reexport_module_3/reexported_function_3/result_1',
       ]),
     }),
   ])
@@ -5355,6 +5378,7 @@
         'tests/data/various_modules_package',
       ]),
       'results': list([
+        'tests/data/various_modules_package/_reexport_module_4/_reexported_function_4/result_1',
       ]),
     }),
     dict({
@@ -5374,6 +5398,7 @@
         'tests/data/various_modules_package',
       ]),
       'results': list([
+        'tests/data/various_modules_package/_reexport_module_4/_reexported_function_4_alias/result_1',
       ]),
     }),
     dict({
@@ -5393,6 +5418,7 @@
         'tests/data/various_modules_package',
       ]),
       'results': list([
+        'tests/data/various_modules_package/_reexport_module_4/_two_times_reexported/result_1',
       ]),
     }),
     dict({
@@ -5411,6 +5437,7 @@
       'reexported_by': list([
       ]),
       'results': list([
+        'tests/data/various_modules_package/_reexport_module_4/_unreexported_function/result_1',
       ]),
     }),
   ])
@@ -5780,6 +5807,7 @@
       'reexported_by': list([
       ]),
       'results': list([
+        'tests/data/various_modules_package/function_module/none_result/result_1',
       ]),
     }),
     dict({

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[_reexport_module_1].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[_reexport_module_1].sdsstub
@@ -1,7 +1,6 @@
 @PythonModule("tests.data.various_modules_package")
 package tests.data.variousModulesPackage
 
-// TODO Result type information missing.
 @Pure
 @PythonName("reexported_function")
 fun reexportedFunction()

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[_reexport_module_2].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[_reexport_module_2].sdsstub
@@ -1,7 +1,6 @@
 @PythonModule("tests.data.various_modules_package")
 package tests.data.variousModulesPackage
 
-// TODO Result type information missing.
 @Pure
 @PythonName("reexported_function_2")
 fun reexportedFunction2()

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[_reexport_module_3].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[_reexport_module_3].sdsstub
@@ -1,7 +1,6 @@
 @PythonModule("tests.data.various_modules_package")
 package tests.data.variousModulesPackage
 
-// TODO Result type information missing.
 @Pure
 @PythonName("reexported_function_3")
 fun reexportedFunction3()

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[_reexport_module_4].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[_reexport_module_4].sdsstub
@@ -1,12 +1,10 @@
 @PythonModule("tests.data.various_modules_package")
 package tests.data.variousModulesPackage
 
-// TODO Result type information missing.
 @Pure
 @PythonName("_reexported_function_4_alias")
 fun reexportedFunction4Alias()
 
-// TODO Result type information missing.
 @Pure
 @PythonName("_two_times_reexported")
 fun twoTimesReexported()

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[function_module].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[function_module].sdsstub
@@ -156,7 +156,6 @@ fun boolResult() -> result1: Boolean
 @PythonName("float_result")
 fun floatResult() -> result1: Float
 
-// TODO Result type information missing.
 @Pure
 @PythonName("none_result")
 fun noneResult()
@@ -281,7 +280,6 @@ class FunctionModuleClassB(
     @PythonName("static_method")
     static fun staticMethod()
 
-    // TODO Result type information missing.
     @Pure
     @PythonName("static_method_params")
     static fun staticMethodParams(

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[full_docstring-PLAINTEXT].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[full_docstring-PLAINTEXT].sdsstub
@@ -7,7 +7,6 @@
 @PythonModule("tests.data.docstring_parser_package.full_docstring")
 package tests.data.docstringParserPackage.fullDocstring
 
-// TODO Result type information missing.
 /**
  * function_with_multi_line_documentation.
  *
@@ -17,7 +16,6 @@ package tests.data.docstringParserPackage.fullDocstring
 @PythonName("function_with_multi_line_documentation")
 fun functionWithMultiLineDocumentation()
 
-// TODO Result type information missing.
 /**
  * function_with_single_line_documentation.
  */
@@ -25,7 +23,6 @@ fun functionWithMultiLineDocumentation()
 @PythonName("function_with_single_line_documentation")
 fun functionWithSingleLineDocumentation()
 
-// TODO Result type information missing.
 @Pure
 @PythonName("function_without_documentation")
 fun functionWithoutDocumentation()

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[googledoc-GOOGLE].sdsstub
@@ -9,7 +9,6 @@ package tests.data.docstringParserPackage.googledoc
 
 from tests.data.variousModulesPackage.anotherPath.anotherModule import AnotherClass
 
-// TODO Result type information missing.
 /**
  * function_with_documentation. Code::
  *
@@ -21,12 +20,10 @@ from tests.data.variousModulesPackage.anotherPath.anotherModule import AnotherCl
 @PythonName("function_with_documentation")
 fun functionWithDocumentation()
 
-// TODO Result type information missing.
 @Pure
 @PythonName("function_without_documentation")
 fun functionWithoutDocumentation()
 
-// TODO Result type information missing.
 // TODO Safe-DS does not support variadic parameters.
 // TODO Some parameter have no type information.
 /**
@@ -52,7 +49,6 @@ fun functionWithParameters(
     kwargs: Map<String, Any>
 )
 
-// TODO Result type information missing.
 // TODO Some parameter have no type information.
 /**
  * function_with_attributes_and_parameters.
@@ -78,7 +74,6 @@ fun functionWithAttributesAndParameters(
 @PythonName("function_with_return_value_and_type")
 fun functionWithReturnValueAndType() -> result1: Boolean
 
-// TODO Result type information missing.
 /**
  * function_with_return_value_no_type.
  *

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
@@ -9,7 +9,6 @@ package tests.data.docstringParserPackage.numpydoc
 
 from tests.data.variousModulesPackage.anotherPath.anotherModule import AnotherClass
 
-// TODO Result type information missing.
 /**
  * function_with_documentation. Code::
  *
@@ -21,12 +20,10 @@ from tests.data.variousModulesPackage.anotherPath.anotherModule import AnotherCl
 @PythonName("function_with_documentation")
 fun functionWithDocumentation()
 
-// TODO Result type information missing.
 @Pure
 @PythonName("function_without_documentation")
 fun functionWithoutDocumentation()
 
-// TODO Result type information missing.
 // TODO Safe-DS does not support variadic parameters.
 // TODO Some parameter have no type information.
 /**

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[plaintext-PLAINTEXT].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[plaintext-PLAINTEXT].sdsstub
@@ -7,7 +7,6 @@
 @PythonModule("tests.data.docstring_parser_package.plaintext")
 package tests.data.docstringParserPackage.plaintext
 
-// TODO Result type information missing.
 /**
  * function_with_documentation.
  *
@@ -19,7 +18,6 @@ fun functionWithDocumentation(
     p: Int
 )
 
-// TODO Result type information missing.
 @Pure
 @PythonName("function_without_documentation")
 fun functionWithoutDocumentation(

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[restdoc-REST].sdsstub
@@ -7,7 +7,6 @@
 @PythonModule("tests.data.docstring_parser_package.restdoc")
 package tests.data.docstringParserPackage.restdoc
 
-// TODO Result type information missing.
 /**
  * function_with_documentation. Code::
  *
@@ -19,12 +18,10 @@ package tests.data.docstringParserPackage.restdoc
 @PythonName("function_with_documentation")
 fun functionWithDocumentation()
 
-// TODO Result type information missing.
 @Pure
 @PythonName("function_without_documentation")
 fun functionWithoutDocumentation()
 
-// TODO Result type information missing.
 // TODO Safe-DS does not support variadic parameters.
 // TODO Some parameter have no type information.
 /**
@@ -61,7 +58,6 @@ fun functionWithParameters(
 @PythonName("function_with_return_value_and_type")
 fun functionWithReturnValueAndType() -> result1: Boolean
 
-// TODO Result type information missing.
 /**
  * function_with_return_value_no_type.
  *


### PR DESCRIPTION
Closes #83

### Summary of Changes
If functions explicitly return `None` they won't get TODO infos anymore.