### PR TITLE
fix: Docstrings have the correct indentation for nested classes (stubs)

### DIFF
--- a/src/safeds_stubgen/stubs_generator/_generate_stubs.py
+++ b/src/safeds_stubgen/stubs_generator/_generate_stubs.py
@@ -350,7 +350,7 @@ class StubsStringGenerator:
         class_text += self._create_class_method_string(class_.methods, inner_indentations)
 
         # Docstring
-        docstring = self._create_sds_docstring(class_.docstring, "", node=class_)
+        docstring = self._create_sds_docstring(class_.docstring, class_indentation, node=class_)
 
         # If the does not have a body, we just return the docstring and signature line
         if not class_text:

--- a/tests/data/various_modules_package/class_module.py
+++ b/tests/data/various_modules_package/class_module.py
@@ -23,10 +23,13 @@ class ClassModuleClassC(ClassModuleEmptyClassA, ClassModuleClassB, yetAnotherCla
 
 class ClassModuleClassD:
     class ClassModuleNestedClassE:
+        """Docstring of the nested class E."""
         nested_attr_1: None
         _nested_attr_2: None
 
-        def class_e_func(self): ...
+        def class_e_func(self):
+            """Docstring of func of nested class E"""
+            ...
 
         class _ClassModulePrivateDoubleNestedClassF:
             def _class_f_func(self): ...

--- a/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
+++ b/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
@@ -1257,8 +1257,8 @@
   list([
     dict({
       'docstring': dict({
-        'description': '',
-        'full_docstring': '',
+        'description': 'Docstring of func of nested class E',
+        'full_docstring': 'Docstring of func of nested class E',
       }),
       'id': 'tests/data/various_modules_package/class_module/ClassModuleClassD/ClassModuleNestedClassE/class_e_func',
       'is_class_method': False,
@@ -2141,8 +2141,8 @@
     ]),
     'constructor': None,
     'docstring': dict({
-      'description': '',
-      'full_docstring': '',
+      'description': 'Docstring of the nested class E.',
+      'full_docstring': 'Docstring of the nested class E.',
     }),
     'id': 'tests/data/various_modules_package/class_module/ClassModuleClassD/ClassModuleNestedClassE',
     'inherits_from_exception': False,

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[class_module].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[class_module].sdsstub
@@ -27,6 +27,9 @@ class ClassModuleClassC() sub ClassModuleEmptyClassA, ClassModuleClassB, yetAnot
 }
 
 class ClassModuleClassD() {
+    /**
+     * Docstring of the nested class E.
+     */
     class ClassModuleNestedClassE() {
         @PythonName("nested_attr_1")
         static attr nestedAttr1: Nothing?
@@ -35,6 +38,9 @@ class ClassModuleClassD() {
         class ClassModulePrivateDoubleNestedClassF()
 
         // TODO Result type information missing.
+        /**
+         * Docstring of func of nested class E
+         */
         @Pure
         @PythonName("class_e_func")
         fun classEFunc()


### PR DESCRIPTION
Closes #113

### Summary of Changes

Fixed the wrong indentation for docstrings in nested classes.