### PR TITLE
fix: Creating stubs with relative paths for source and output directories

### DIFF
--- a/src/safeds_stubgen/api_analyzer/cli/_cli.py
+++ b/src/safeds_stubgen/api_analyzer/cli/_cli.py
@@ -17,7 +17,7 @@ def cli() -> None:
     if args.verbose:
         logging.basicConfig(level=logging.INFO)
 
-    _run_stub_generator(args.src, args.out, args.docstyle, args.testrun, args.naming_convert)
+    _run_stub_generator(args.src.resolve(), args.out.resolve(), args.docstyle, args.testrun, args.naming_convert)
 
 
 def _get_args() -> argparse.Namespace:


### PR DESCRIPTION
Closes #125

### Summary of Changes

Fixed a bug where the stub generator would not run or run buggy with relative paths as source and / or output directories.