### PR TITLE
fix: Include lines of examples that start with `...`

### DIFF
--- a/src/safeds_stubgen/stubs_generator/_generate_stubs.py
+++ b/src/safeds_stubgen/stubs_generator/_generate_stubs.py
@@ -944,6 +944,8 @@ class StubsStringGenerator:
             for example_part in docstring.example.split("\n"):
                 if example_part.startswith(">>>"):
                     example += f"{indentations} *     {example_part.replace('>>>', '//')}\n"
+                elif example_part.startswith("..."):
+                    example += f"{indentations} *     {example_part.replace('...', '//')}\n"
             example += f"{indentations} * }}\n"
         if full_docstring and example:
             full_docstring += f"{indentations} *\n"

--- a/tests/data/docstring_parser_package/numpydoc.py
+++ b/tests/data/docstring_parser_package/numpydoc.py
@@ -488,7 +488,9 @@ class NumpyClassWithExamples:
     --------
     >>> from tests.data.docstring_parser_package.numpydoc import NumpyClassWithExamples
     This text should be ignored
-    >>> class_ = NumpyClassWithExamples
+    >>> class_ = (
+    ...     NumpyClassWithExamples
+    ... )
     This text should be ignored, too.
     """
 
@@ -497,7 +499,9 @@ class NumpyClassWithExamples:
         Examples
         --------
         >>> from tests.data.docstring_parser_package.numpydoc import NumpyClassWithExamples
-        >>> func = NumpyClassWithExamples.numpy_func_with_examples
+        >>> func = (
+        ...     NumpyClassWithExamples.numpy_func_with_examples
+        ... )
         >>> func()
         This text should be ignored.
         """

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
@@ -411,7 +411,9 @@ class ClassWithVariousAttributeTypes() {
  * @example
  * pipeline example {
  *     // from tests.data.docstring_parser_package.numpydoc import NumpyClassWithExamples
- *     // class_ = NumpyClassWithExamples
+ *     // class_ = (
+ *     //     NumpyClassWithExamples
+ *     // )
  * }
  */
 class NumpyClassWithExamples() {
@@ -420,7 +422,9 @@ class NumpyClassWithExamples() {
      * @example
      * pipeline example {
      *     // from tests.data.docstring_parser_package.numpydoc import NumpyClassWithExamples
-     *     // func = NumpyClassWithExamples.numpy_func_with_examples
+     *     // func = (
+     *     //     NumpyClassWithExamples.numpy_func_with_examples
+     *     // )
      *     // func()
      * }
      */


### PR DESCRIPTION
Closes #129

### Summary of Changes

Lines of examples that start with `...` are now included in the generated stubs.
