### PR TITLE
docs: adjust descriptions of parameters and results to styleguide

### DIFF
--- a/src/safeds_stubgen/api_analyzer/_api.py
+++ b/src/safeds_stubgen/api_analyzer/_api.py
@@ -28,7 +28,7 @@ def ensure_file_exists(file: Path) -> None:
 
     Parameters
     ----------
-    file: Path
+    file:
         The file path.
     """
     file.parent.mkdir(parents=True, exist_ok=True)

--- a/src/safeds_stubgen/api_analyzer/_ast_visitor.py
+++ b/src/safeds_stubgen/api_analyzer/_ast_visitor.py
@@ -551,16 +551,16 @@ class MyPyAstVisitor:
 
         Paramters
         ---------
-        ret_type : sds_types.TupleType
+        ret_type:
             An object representing a tuple with all inferred types.
-        result_docstring : ResultDocstring
+        result_docstring:
             The docstring of the function to which the results belong to.
-        function_id : str
+        function_id:
             The function ID.
 
         Returns
         -------
-        list[Result]
+        results:
             A list of Results objects representing the possible results of a funtion.
         """
         result_array: list[list[AbstractType]] = []
@@ -1124,12 +1124,12 @@ class MyPyAstVisitor:
 
         Paramters
         ---------
-        name : str
+        name:
             The name of the new object which lies on the highest level.
 
         Returns
         -------
-        str
+        id:
             ID of the object
         """
         segments = [

--- a/src/safeds_stubgen/api_analyzer/cli/_cli.py
+++ b/src/safeds_stubgen/api_analyzer/cli/_cli.py
@@ -76,11 +76,11 @@ def _run_stub_generator(
 
     Parameters
     ----------
-    out_dir_path : Path
+    out_dir_path:
         The path to the output directory.
-    docstring_style : DocstringStyle
+    docstring_style:
         The style of docstrings that used in the library.
-    is_test_run : bool
+    is_test_run:
         Set True if files in test directories should be parsed too.
     """
     # Generate the API data

--- a/src/safeds_stubgen/stubs_generator/_generate_stubs.py
+++ b/src/safeds_stubgen/stubs_generator/_generate_stubs.py
@@ -46,16 +46,17 @@ def generate_stub_data(
 
     Parameters
     ----------
-    stubs_generator
+    stubs_generator:
         The class for generating the stubs.
-    out_path
+    out_path:
         The path in which the stub files should be created. If no such path exists this function creates the directory
         files.
 
     Returns
     -------
-    A list of tuples, which are 1. the path of the stub file, 2. the name of the stub file, 3. its content and 4. if
-    it's a package file (created through init reexports).
+    virtual_files:
+        A list of tuples, which are 1. the path of the stub file, 2. the name of the stub file, 3. its content and 4. if
+        it's a package file (created through init reexports).
     """
     api = stubs_generator.api
     stubs_data: list[tuple[Path, str, str, bool]] = []
@@ -1119,7 +1120,7 @@ class StubsStringGenerator:
 
         Paramters
         ---------
-        qname
+        qname:
             The qualified name of a module/class/etc.
         """
         if import_qname == "":  # pragma: no cover


### PR DESCRIPTION
Closes #58

### Summary of Changes

Remove types of parameters and results in docstrings. This easily lead to inconsistencies.
