### PR TITLE
feat: Combine multiple examples to one

### DIFF
--- a/src/safeds_stubgen/docstring_parsing/_docstring.py
+++ b/src/safeds_stubgen/docstring_parsing/_docstring.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class ClassDocstring:
     description: str = ""
     full_docstring: str = ""
-    example: str = ""
+    examples: list[str] = dataclasses.field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)
@@ -24,7 +24,7 @@ class ClassDocstring:
 class FunctionDocstring:
     description: str = ""
     full_docstring: str = ""
-    example: str = ""
+    examples: list[str] = dataclasses.field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return dataclasses.asdict(self)

--- a/src/safeds_stubgen/docstring_parsing/_docstring_parser.py
+++ b/src/safeds_stubgen/docstring_parsing/_docstring_parser.py
@@ -58,7 +58,10 @@ class DocstringParser(AbstractDocstringParser):
                 if docstring_section.kind == DocstringSectionKind.text:
                     description = docstring_section.value.strip("\n")
                 elif docstring_section.kind == DocstringSectionKind.examples:
-                    example = docstring_section.value[0][1].strip("\n")
+                    examples = []
+                    for example_data in docstring_section.value:
+                        examples.append(example_data[1].strip("\n"))
+                    example = "\n".join(examples)
 
         return ClassDocstring(
             description=description,
@@ -77,7 +80,10 @@ class DocstringParser(AbstractDocstringParser):
                 if docstring_section.kind == DocstringSectionKind.text:
                     description = docstring_section.value.strip("\n")
                 elif docstring_section.kind == DocstringSectionKind.examples:
-                    example = docstring_section.value[0][1].strip("\n")
+                    examples = []
+                    for example_data in docstring_section.value:
+                        examples.append(example_data[1].strip("\n"))
+                    example = "\n".join(examples)
 
         return FunctionDocstring(
             description=description,

--- a/src/safeds_stubgen/docstring_parsing/_docstring_parser.py
+++ b/src/safeds_stubgen/docstring_parsing/_docstring_parser.py
@@ -50,7 +50,7 @@ class DocstringParser(AbstractDocstringParser):
 
         description = ""
         docstring = ""
-        example = ""
+        examples = []
         if griffe_node.docstring is not None:
             docstring = griffe_node.docstring.value.strip("\n")
 
@@ -58,21 +58,19 @@ class DocstringParser(AbstractDocstringParser):
                 if docstring_section.kind == DocstringSectionKind.text:
                     description = docstring_section.value.strip("\n")
                 elif docstring_section.kind == DocstringSectionKind.examples:
-                    examples = []
                     for example_data in docstring_section.value:
                         examples.append(example_data[1].strip("\n"))
-                    example = "\n".join(examples)
 
         return ClassDocstring(
             description=description,
             full_docstring=docstring,
-            example=example,
+            examples=examples,
         )
 
     def get_function_documentation(self, function_node: nodes.FuncDef) -> FunctionDocstring:
         docstring = ""
         description = ""
-        example = ""
+        examples = []
         griffe_docstring = self.__get_cached_docstring(function_node.fullname)
         if griffe_docstring is not None:
             docstring = griffe_docstring.value.strip("\n")
@@ -80,15 +78,13 @@ class DocstringParser(AbstractDocstringParser):
                 if docstring_section.kind == DocstringSectionKind.text:
                     description = docstring_section.value.strip("\n")
                 elif docstring_section.kind == DocstringSectionKind.examples:
-                    examples = []
                     for example_data in docstring_section.value:
                         examples.append(example_data[1].strip("\n"))
-                    example = "\n".join(examples)
 
         return FunctionDocstring(
             description=description,
             full_docstring=docstring,
-            example=example,
+            examples=examples,
         )
 
     def get_parameter_documentation(

--- a/src/safeds_stubgen/stubs_generator/_stub_string_generator.py
+++ b/src/safeds_stubgen/stubs_generator/_stub_string_generator.py
@@ -894,18 +894,23 @@ class StubsStringGenerator:
         full_docstring += full_result_docstring
 
         # Example
-        example = ""
-        if not isinstance(docstring, AttributeDocstring) and docstring.example:
-            example = f"{indentations} * @example\n{indentations} * pipeline example {{\n"
-            for example_part in docstring.example.split("\n"):
-                if example_part.startswith(">>>"):
-                    example += f"{indentations} *     {example_part.replace('>>>', '//')}\n"
-                elif example_part.startswith("..."):
-                    example += f"{indentations} *     {example_part.replace('...', '//')}\n"
-            example += f"{indentations} * }}\n"
-        if full_docstring and example:
+        example_docstrings = []
+        if not isinstance(docstring, AttributeDocstring) and docstring.examples:
+            for example in docstring.examples:
+                example_text = f"{indentations} * @example\n{indentations} * pipeline example {{\n"
+                for example_part in example.split("\n"):
+                    if example_part.startswith(">>>"):
+                        example_text += f"{indentations} *     {example_part.replace('>>>', '//')}\n"
+                    elif example_part.startswith("..."):
+                        example_text += f"{indentations} *     {example_part.replace('...', '//')}\n"
+                example_text += f"{indentations} * }}\n"
+                example_docstrings.append(example_text)
+
+        if full_docstring and example_docstrings:
             full_docstring += f"{indentations} *\n"
-        full_docstring += example
+
+        example_docstring = f"{indentations} *\n".join(example_docstrings)
+        full_docstring += example_docstring
 
         # Open and close the docstring
         if full_docstring:

--- a/tests/data/docstring_parser_package/numpydoc.py
+++ b/tests/data/docstring_parser_package/numpydoc.py
@@ -548,3 +548,29 @@ def numpy_named_result_without_type_inferred():
         this will be the return value
     """
     return "result"
+
+
+class ClassWithExample:
+    """
+    Examples
+    --------
+    >>> print(1+1)
+    2
+
+    >>> x = 2 - 1
+    >>> print(x)
+    1
+    """
+
+
+def function_with_example() -> None:
+    """
+    Examples
+    --------
+    >>> print(1+1)
+    2
+
+    >>> x = 2 - 1
+    >>> print(x)
+    1
+    """

--- a/tests/safeds_stubgen/__snapshots__/test_main.ambr
+++ b/tests/safeds_stubgen/__snapshots__/test_main.ambr
@@ -102,7 +102,8 @@
         'constructor': None,
         'docstring': dict({
           'description': '',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '',
         }),
         'id': 'tests/data/main_package/another_path/another_module/AnotherClass',
@@ -126,7 +127,8 @@
         'constructor': None,
         'docstring': dict({
           'description': '',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '',
         }),
         'id': 'tests/data/main_package/another_path/another_module/yetAnotherClass',
@@ -159,7 +161,8 @@
               
               Full init description.
             ''',
-            'example': '',
+            'examples': list([
+            ]),
             'full_docstring': '''
               Summary of the init description.
               
@@ -187,7 +190,8 @@
             
             Full description
           ''',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '''
             Summary of the description.
             
@@ -217,7 +221,8 @@
         'constructor': None,
         'docstring': dict({
           'description': '',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '',
         }),
         'id': 'tests/data/main_package/main_module/ModuleClass/NestedClass',
@@ -246,7 +251,8 @@
         'constructor': dict({
           'docstring': dict({
             'description': '',
-            'example': '',
+            'examples': list([
+            ]),
             'full_docstring': '',
           }),
           'id': 'tests/data/main_package/main_module/_PrivateClass/__init__',
@@ -265,7 +271,8 @@
         }),
         'docstring': dict({
           'description': '',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '',
         }),
         'id': 'tests/data/main_package/main_module/_PrivateClass',
@@ -292,7 +299,8 @@
         'constructor': None,
         'docstring': dict({
           'description': '',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '',
         }),
         'id': 'tests/data/main_package/main_module/_PrivateClass/NestedPrivateClass',
@@ -317,7 +325,8 @@
         'constructor': None,
         'docstring': dict({
           'description': '',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '',
         }),
         'id': 'tests/data/main_package/main_module/_PrivateClass/NestedPrivateClass/NestedNestedPrivateClass',
@@ -343,7 +352,8 @@
       dict({
         'docstring': dict({
           'description': '',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '',
         }),
         'id': 'tests/data/main_package/another_path/another_module/yetAnotherClass/another_function',
@@ -364,7 +374,8 @@
       dict({
         'docstring': dict({
           'description': '',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '',
         }),
         'id': 'tests/data/main_package/main_module/ModuleClass/NestedClass/nested_class_function',
@@ -390,7 +401,8 @@
             
             Full init description.
           ''',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '''
             Summary of the init description.
             
@@ -419,7 +431,8 @@
             
             param_2: bool.
           ''',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '''
             Function Docstring.
             
@@ -446,7 +459,8 @@
       dict({
         'docstring': dict({
           'description': '',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '',
         }),
         'id': 'tests/data/main_package/main_module/_PrivateClass/NestedPrivateClass/static_nested_private_class_function',
@@ -465,7 +479,8 @@
       dict({
         'docstring': dict({
           'description': '',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '',
         }),
         'id': 'tests/data/main_package/main_module/_PrivateClass/__init__',
@@ -485,7 +500,8 @@
       dict({
         'docstring': dict({
           'description': '',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '',
         }),
         'id': 'tests/data/main_package/main_module/_PrivateClass/public_func_in_private_class',
@@ -505,7 +521,8 @@
       dict({
         'docstring': dict({
           'description': '',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '',
         }),
         'id': 'tests/data/main_package/main_module/_private_global_func',
@@ -529,7 +546,8 @@
             
             Docstring 2.
           ''',
-          'example': '',
+          'examples': list([
+          ]),
           'full_docstring': '''
             Docstring 1.
             

--- a/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
+++ b/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
@@ -1103,7 +1103,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/abstract_module/AbstractModuleClass/abstract_method',
@@ -1123,7 +1124,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/abstract_module/AbstractModuleClass/abstract_method_params',
@@ -1147,7 +1149,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/abstract_module/AbstractModuleClass/abstract_property_method',
@@ -1169,7 +1172,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/abstract_module/AbstractModuleClass/abstract_static_method',
@@ -1188,7 +1192,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/abstract_module/AbstractModuleClass/abstract_static_method_params',
@@ -1213,7 +1218,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/class_module/ClassModuleClassB/f',
@@ -1237,7 +1243,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/class_module/ClassModuleClassC/f1',
@@ -1265,7 +1272,8 @@
     dict({
       'docstring': dict({
         'description': 'Docstring of func of nested class E',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': 'Docstring of func of nested class E',
       }),
       'id': 'tests/data/various_modules_package/class_module/ClassModuleClassD/ClassModuleNestedClassE/class_e_func',
@@ -1289,7 +1297,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/type_var_module/CollectionTypeVar2/type_var_class_method2',
@@ -1315,7 +1324,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/type_var_module/CollectionTypeVar/type_var_class_method',
@@ -1341,7 +1351,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/FunctionModuleClassB/class_method',
@@ -1361,7 +1372,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/FunctionModuleClassB/class_method_params',
@@ -1383,7 +1395,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/FunctionModuleClassB/instance_method',
@@ -1405,7 +1418,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/FunctionModuleClassB/static_method',
@@ -1424,7 +1438,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/FunctionModuleClassB/static_method_params',
@@ -1449,7 +1464,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/FunctionModuleClassB/FunctionModuleClassC/nested_class_function',
@@ -1475,7 +1491,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/FunctionModulePropertiesClass/property_function',
@@ -1495,7 +1512,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/FunctionModulePropertiesClass/property_function_infer',
@@ -1516,7 +1534,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/FunctionModulePropertiesClass/property_function_params',
@@ -1541,7 +1560,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/type_var_module/GenericTypeVar2/type_var_class_method2',
@@ -1567,7 +1587,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/type_var_module/GenericTypeVar/type_var_class_method',
@@ -1598,7 +1619,8 @@
           This function checks if the sum of x and y is less than the value 10
           and returns True if it is. (Google Style)
         ''',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '''
           Checks if the sum of two variables is over the value of 10. (Google Style).
           
@@ -1638,7 +1660,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/infer_types_module/InferMyTypes/_',
@@ -1659,7 +1682,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/infer_types_module/InferMyTypes/infer_call_result_1',
@@ -1679,7 +1703,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/infer_types_module/InferMyTypes/infer_call_result_2',
@@ -1699,7 +1724,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/infer_types_module/InferMyTypes/infer_function',
@@ -1723,7 +1749,8 @@
     dict({
       'docstring': dict({
         'description': 'Test for inferring results with just one possible result, and not a tuple of results.',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': 'Test for inferring results with just one possible result, and not a tuple of results.',
       }),
       'id': 'tests/data/various_modules_package/infer_types_module/InferMyTypes/infer_function_2',
@@ -1744,7 +1771,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/infer_types_module/InferMyTypes/infer_param_types',
@@ -1781,7 +1809,8 @@
           
           This function checks if the sum of `x` and `y` is less than the value 10 and returns True if it is. (Numpy)
         ''',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '''
           Checks if the sum of two variables is over the value of 10. (Numpy).
           
@@ -1824,7 +1853,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/_reexport_module_1/ReexportClass/_private_class_method_of_reexported_class',
@@ -1851,7 +1881,8 @@
           This function checks if the sum of x and y is less than the value 10
           and returns True if it is. (ReST).
         ''',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '''
           This function checks if the sum of x and y is less than the value 10
           and returns True if it is. (ReST).
@@ -1888,7 +1919,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/type_var_module/SequenceTypeVar2/type_var_class_method2',
@@ -1914,7 +1946,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/type_var_module/SequenceTypeVar/type_var_class_method',
@@ -1940,7 +1973,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/class_module/ClassModuleClassD/ClassModuleNestedClassE/_ClassModulePrivateDoubleNestedClassF/_class_f_func',
@@ -1968,7 +2002,8 @@
     'constructor': dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/abstract_module/AbstractModuleClass/__init__',
@@ -1988,7 +2023,8 @@
     }),
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/abstract_module/AbstractModuleClass',
@@ -2020,7 +2056,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/_reexport_module_2/AnotherUnreexportedClass',
@@ -2046,7 +2083,8 @@
     'constructor': dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/class_module/ClassModuleClassB/__init__',
@@ -2067,7 +2105,8 @@
     }),
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/class_module/ClassModuleClassB',
@@ -2097,7 +2136,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/class_module/ClassModuleClassC',
@@ -2128,7 +2168,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/class_module/ClassModuleClassD',
@@ -2155,7 +2196,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/class_module/ClassModuleEmptyClassA',
@@ -2184,7 +2226,8 @@
     'constructor': None,
     'docstring': dict({
       'description': 'Docstring of the nested class E.',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': 'Docstring of the nested class E.',
     }),
     'id': 'tests/data/various_modules_package/class_module/ClassModuleClassD/ClassModuleNestedClassE',
@@ -2211,7 +2254,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/_reexport_module_4/FourthReexportClass',
@@ -2239,7 +2283,8 @@
     'constructor': dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/docstring_module/GoogleDocstringClass/__init__',
@@ -2263,7 +2308,8 @@
         
         A class with a variety of different methods for calculations. (Google Style)
       ''',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '''
         A class that calculates stuff. (Google Style).
         
@@ -2308,7 +2354,8 @@
     'constructor': dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/infer_types_module/InferMyTypes/__init__',
@@ -2328,7 +2375,8 @@
     }),
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/infer_types_module/InferMyTypes',
@@ -2361,7 +2409,8 @@
     'constructor': dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/docstring_module/NumpyDocstringClass/__init__',
@@ -2385,7 +2434,8 @@
         
         A class with a variety of different methods for calculations. (Numpy)
       ''',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '''
         A class that calculates stuff. (Numpy).
         
@@ -2426,7 +2476,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/_reexport_module_1/ReexportClass',
@@ -2455,7 +2506,8 @@
     'constructor': dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/docstring_module/RestDocstringClass/__init__',
@@ -2475,7 +2527,8 @@
     }),
     'docstring': dict({
       'description': 'A class with a variety of different methods for calculations. (ReST).',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '''
         A class with a variety of different methods for calculations. (ReST).
         
@@ -2509,7 +2562,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/variance_module/VarianceClassAll',
@@ -2584,7 +2638,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/variance_module/VarianceClassOnlyContravarianceNoBound',
@@ -2615,7 +2670,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/variance_module/VarianceClassOnlyCovarianceNoBound',
@@ -2646,7 +2702,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/variance_module/VarianceClassOnlyVarianceNoBound',
@@ -2679,7 +2736,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/class_module/_ClassModulePrivateClassG',
@@ -2705,7 +2763,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/class_module/ClassModuleClassD/ClassModuleNestedClassE/_ClassModulePrivateDoubleNestedClassF',
@@ -2732,7 +2791,8 @@
     'constructor': None,
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/_reexport_module_3/_ThirdReexportClass',
@@ -2807,7 +2867,8 @@
   dict({
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/enum_module/EnumTest2',
@@ -2821,7 +2882,8 @@
   dict({
     'docstring': dict({
       'description': '',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '',
     }),
     'id': 'tests/data/various_modules_package/enum_module/EnumTest3',
@@ -2839,7 +2901,8 @@
         
         Full Docstring Description
       ''',
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': '''
         Enum Docstring.
         
@@ -2865,7 +2928,8 @@
   dict({
     'docstring': dict({
       'description': "Nothing's here.",
-      'example': '',
+      'examples': list([
+      ]),
       'full_docstring': "Nothing's here.",
     }),
     'id': 'tests/data/various_modules_package/enum_module/_ReexportedEmptyEnum',
@@ -5588,7 +5652,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/_reexport_module_1/reexported_function',
@@ -5612,7 +5677,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/_reexport_module_2/reexported_function_2',
@@ -5637,7 +5703,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/_reexport_module_3/reexported_function_3',
@@ -5663,7 +5730,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/_reexport_module_4/_reexported_function_4',
@@ -5684,7 +5752,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/_reexport_module_4/_reexported_function_4_alias',
@@ -5705,7 +5774,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/_reexport_module_4/_two_times_reexported',
@@ -5726,7 +5796,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/_reexport_module_4/_unreexported_function',
@@ -5750,7 +5821,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/_private',
@@ -5770,7 +5842,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/any_results',
@@ -5790,7 +5863,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/arg',
@@ -5811,7 +5885,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/args_type',
@@ -5832,7 +5907,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/bool_result',
@@ -5852,7 +5928,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/callable_type',
@@ -5873,7 +5950,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/callexr_result_class',
@@ -5892,7 +5970,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/callexr_result_function',
@@ -5911,7 +5990,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/dictionary_results',
@@ -5931,7 +6011,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/dictionary_results_no_key_no_value',
@@ -5951,7 +6032,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/float_result',
@@ -5971,7 +6053,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/illegal_dictionary_results',
@@ -5991,7 +6074,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/illegal_list_results',
@@ -6011,7 +6095,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/illegal_params',
@@ -6035,7 +6120,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/illegal_set_results',
@@ -6055,7 +6141,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/int_result',
@@ -6075,7 +6162,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/list_results',
@@ -6095,7 +6183,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/literal_results',
@@ -6115,7 +6204,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/none_result',
@@ -6135,7 +6225,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/obj_result',
@@ -6155,7 +6246,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/opt_pos_only',
@@ -6176,7 +6268,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/optional_results',
@@ -6196,7 +6289,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/param_from_outside_the_package',
@@ -6217,7 +6311,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/param_position',
@@ -6242,7 +6337,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/params',
@@ -6286,7 +6382,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/params_with_default_value',
@@ -6322,7 +6419,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/public_no_params_no_result',
@@ -6341,7 +6439,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/req_name_only',
@@ -6362,7 +6461,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/result_from_outside_the_package',
@@ -6382,7 +6482,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/ret_conditional_statement',
@@ -6402,7 +6503,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/set_results',
@@ -6422,7 +6524,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/special_params',
@@ -6450,7 +6553,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/str_result',
@@ -6470,7 +6574,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/tuple_results',
@@ -6491,7 +6596,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/union_dictionary_results',
@@ -6511,7 +6617,8 @@
     dict({
       'docstring': dict({
         'description': '',
-        'example': '',
+        'examples': list([
+        ]),
         'full_docstring': '',
       }),
       'id': 'tests/data/various_modules_package/function_module/union_results',

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
@@ -197,6 +197,10 @@ fun numpyNamedResultWithoutTypeInferred() -> namedResult: String
  * @example
  * pipeline example {
  *     // print(1+1)
+ * }
+ *
+ * @example
+ * pipeline example {
  *     // x = 2 - 1
  *     // print(x)
  * }
@@ -480,6 +484,10 @@ class NumpyClassWithExamples() {
  * @example
  * pipeline example {
  *     // print(1+1)
+ * }
+ *
+ * @example
+ * pipeline example {
  *     // x = 2 - 1
  *     // print(x)
  * }

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
@@ -194,6 +194,18 @@ fun numpyNamedResultWithoutType() -> namedResult: String
 fun numpyNamedResultWithoutTypeInferred() -> namedResult: String
 
 /**
+ * @example
+ * pipeline example {
+ *     // print(1+1)
+ *     // x = 2 - 1
+ *     // print(x)
+ * }
+ */
+@Pure
+@PythonName("function_with_example")
+fun functionWithExample()
+
+/**
  * ClassWithDocumentation. Code::
  *
  *     pass
@@ -463,6 +475,16 @@ class NumpyClassWithExamples() {
     @PythonName("numpy_func_with_examples")
     fun numpyFuncWithExamples()
 }
+
+/**
+ * @example
+ * pipeline example {
+ *     // print(1+1)
+ *     // x = 2 - 1
+ *     // print(x)
+ * }
+ */
+class ClassWithExample()
 
 /**
  * EnumDocstring.


### PR DESCRIPTION
Closes #139

### Summary of Changes
Multiple example docstrings ~~are now combined to one big example docstrings~~ will now each have an example block in Safe-DS docstrings. Previously only the first docstring was saved and others where ignored.