### PR TITLE
fix: Nested internal classes won't create stubs

### DIFF
--- a/src/safeds_stubgen/stubs_generator/_stub_string_generator.py
+++ b/src/safeds_stubgen/stubs_generator/_stub_string_generator.py
@@ -285,12 +285,13 @@ class StubsStringGenerator:
 
         # Inner classes
         for inner_class in class_.classes:
-            class_string = self._create_class_string(
-                class_=inner_class,
-                class_indentation=inner_indentations,
-                in_reexport_module=in_reexport_module,
-            )
-            class_text += f"\n{class_string}\n"
+            if inner_class.is_public:
+                class_string = self._create_class_string(
+                    class_=inner_class,
+                    class_indentation=inner_indentations,
+                    in_reexport_module=in_reexport_module,
+                )
+                class_text += f"\n{class_string}\n"
 
         # Superclass methods, if the superclass is an internal class
         class_text += superclass_methods_text

--- a/src/safeds_stubgen/stubs_generator/_stub_string_generator.py
+++ b/src/safeds_stubgen/stubs_generator/_stub_string_generator.py
@@ -263,10 +263,12 @@ class StubsStringGenerator:
         # Inner classes
         for inner_class in class_.classes:
             if inner_class.is_public:
+                # We set in_reexport_module to True since nested classes alone can't be reexported and are bound to
+                # their parent class
                 class_string = self._create_class_string(
                     class_=inner_class,
                     class_indentation=inner_indentations,
-                    in_reexport_module=in_reexport_module,
+                    in_reexport_module=True,
                 )
                 class_text += f"\n{class_string}\n"
 

--- a/tests/data/various_modules_package/class_module.py
+++ b/tests/data/various_modules_package/class_module.py
@@ -34,6 +34,9 @@ class ClassModuleClassD:
         class _ClassModulePrivateDoubleNestedClassF:
             def _class_f_func(self): ...
 
+    class _PrivatNestedClass:
+        ...
+
 
 class _ClassModulePrivateClassG:
     _attr_1: float

--- a/tests/data/various_modules_package/class_module.py
+++ b/tests/data/various_modules_package/class_module.py
@@ -34,7 +34,7 @@ class ClassModuleClassD:
         class _ClassModulePrivateDoubleNestedClassF:
             def _class_f_func(self): ...
 
-    class _PrivatNestedClass:
+    class _PrivateNestedClass:
         ...
 
 

--- a/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
+++ b/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
@@ -2124,6 +2124,7 @@
     ]),
     'classes': list([
       'tests/data/various_modules_package/class_module/ClassModuleClassD/ClassModuleNestedClassE',
+      'tests/data/various_modules_package/class_module/ClassModuleClassD/_PrivatNestedClass',
     ]),
     'constructor': None,
     'docstring': dict({

--- a/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
+++ b/tests/safeds_stubgen/api_analyzer/__snapshots__/test__get_api.ambr
@@ -2124,7 +2124,7 @@
     ]),
     'classes': list([
       'tests/data/various_modules_package/class_module/ClassModuleClassD/ClassModuleNestedClassE',
-      'tests/data/various_modules_package/class_module/ClassModuleClassD/_PrivatNestedClass',
+      'tests/data/various_modules_package/class_module/ClassModuleClassD/_PrivateNestedClass',
     ]),
     'constructor': None,
     'docstring': dict({

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[ClMCD].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/TestStubFileGeneration.test_stub_creation[ClMCD].sdsstub
@@ -9,9 +9,6 @@ class ClMCD() {
         @PythonName("nested_attr_1")
         static attr nestedAttr1: Nothing?
 
-        @PythonName("_ClassModulePrivateDoubleNestedClassF")
-        class ClassModulePrivateDoubleNestedClassF()
-
         // TODO Result type information missing.
         /**
          * Docstring of func of nested class E


### PR DESCRIPTION
Closes #143 

### Summary of Changes
Fixed a bug where nested internal classes would create stubs even though stubs should not be created for these internal classes.