### PR TITLE
fix: Result names for multiple results from docstrings

### DIFF
--- a/src/safeds_stubgen/api_analyzer/_ast_visitor.py
+++ b/src/safeds_stubgen/api_analyzer/_ast_visitor.py
@@ -476,6 +476,19 @@ class MyPyAstVisitor:
                     name=f"{result_name}",
                 ),
             ]
+        elif len(return_results) == len(result_docstrings):
+            zipped = zip(return_results, result_docstrings, strict=True)
+
+            for type_, result_docstring in zipped:
+                result_name = result_docstring.name or next(name_generator)
+
+                all_results.append(
+                    Result(
+                        id=f"{function_id}/{result_name}",
+                        type=type_,
+                        name=f"{result_name}",
+                    ),
+                )
         else:
             for type_ in return_results:
                 result_docstring = ResultDocstring()

--- a/tests/data/docstring_parser_package/numpydoc.py
+++ b/tests/data/docstring_parser_package/numpydoc.py
@@ -548,3 +548,15 @@ def numpy_named_result_without_type_inferred():
         this will be the return value
     """
     return "result"
+
+
+def numpy_named_result_with_more_hints_than_docstring_types() -> tuple[int, str]:
+    """
+    numpy_named_result_without_type_inferred
+
+    Returns
+    -------
+    named_result : int
+        this will be the return value
+    """
+    ...

--- a/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
+++ b/tests/safeds_stubgen/stubs_generator/__snapshots__/test_generate_stubs/test_stub_docstring_creation[numpydoc-NUMPYDOC].sdsstub
@@ -194,6 +194,15 @@ fun numpyNamedResultWithoutType() -> namedResult: String
 fun numpyNamedResultWithoutTypeInferred() -> namedResult: String
 
 /**
+ * numpy_named_result_without_type_inferred
+ *
+ * @result namedResult this will be the return value
+ */
+@Pure
+@PythonName("numpy_named_result_with_more_hints_than_docstring_types")
+fun numpyNamedResultWithMoreHintsThanDocstringTypes() -> (namedResult: Int, result1: String)
+
+/**
  * ClassWithDocumentation. Code::
  *
  *     pass


### PR DESCRIPTION
Closes #138

### Summary of Changes

If number of results and docstrings types correspond then docstring names are taken for the results.